### PR TITLE
Close up bogus space in "PrestoSQL"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <!--Main Navigation-->
 <header>
     <div class="announcement">
-      <h2>Presto SQL is now Trino <a href="{% post_url
+      <h2>PrestoSQL is now Trino <a href="{% post_url
         2020-12-27-announcing-trino %}">Read why &raquo;</a></h2>
     </div>
     <nav class="navbar navbar-expand-lg navbar-dark scrolling-navbar" style="background: #000033;height:80px;">


### PR DESCRIPTION
The pink banner misspelled PrestoSQL as Presto SQL. This is a single character commit that closes up that space.