### PR TITLE
Fix formatting of footer of users page

### DIFF
--- a/users.md
+++ b/users.md
@@ -58,14 +58,12 @@ title: Users
 </div>
 {% endfor %}
 
-<div class="row spacer-30">
-  <div class="row">
-    <div class="col-md-12 col-s-12">
-    <h1>Are you a user too?</h1>
-    <p>We are happy to include your testimonial! Contact us on the
-      <a href="./slack.html">community chat</a>, and we will get you added.</p>
-    </div>
-  </div>
-</div>
+<div markdown="1" class="row spacer-60 col-md-12 leftcol widecol">
 
+# Are you a user too?
+
+We are happy to include your testimonial! Contact us on the
+[community chat](slack.html), and we will get you added.
+
+</div>
 </div>


### PR DESCRIPTION
Text in footer was glued to left side of the container which did not look great on the phone.

before: 

![image](https://user-images.githubusercontent.com/890111/104698174-3f1f2b80-5711-11eb-91f5-69b1bc6e68e9.png)

after: 

![image](https://user-images.githubusercontent.com/890111/104698150-30d10f80-5711-11eb-9f3e-d0f51c700128.png)
