### PR TITLE
Community Broadcast page updates

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -336,6 +336,131 @@ table td {
 .container__episode {padding-bottom: 4rem;}
 .container__episode h2:not(:first-of-type) {margin-top: 3.5rem;}
 
+.container__broadcast .watch-listen-icon {margin: 0 4px;}
+
+.container__broadcast .latest-entry {
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+}
+
+@media (max-width: 414px) {
+  .container__broadcast .latest-entry {
+    padding: 1.5rem;
+  }
+}
+
+.container__broadcast .latest-entry .latest-entry-text-container {
+  margin-right: 3rem;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  max-width: 50%;
+}
+
+@media (max-width: 990px) {
+  .container__broadcast .latest-entry .latest-entry-text-container {
+    margin-right: 0;
+    margin-top: 1rem;
+    max-width: initial;
+  }
+}
+
+.container__broadcast .latest-entry .latest-entry-video-container {
+  width: 100%;
+  overflow:hidden;
+}
+
+.container__broadcast .latest-entry .latest-entry-video-wrapper {
+  padding-top: 56.25%; /* Used to maintain a fluid 16:9 ratio */
+  height: 0px;
+  position: relative;
+}
+
+.container__broadcast .latest-entry .latest-entry-video-wrapper iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.container__broadcast .post-entry a {
+  margin-top: auto;
+}
+
+.container__broadcast .post-entry ul {
+  padding-inline-start: 1.25rem;
+}
+
+.container__broadcast .post-entry ul li {
+  margin-bottom: 0.25rem;
+}
+
+.previous-episode-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.previous-episode-header p {
+  margin-bottom: 0;
+  margin-left: 1rem;
+}
+
+@media (max-width: 414px) {
+  .previous-episode-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .previous-episode-header p{
+    margin-left: 0;
+  }
+}
+
+.episode-grid {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+}
+
+.episode-grid .post-entry {
+  max-width: calc(33.33% - 1rem); /* 3 Column */
+  -ms-flex: calc(33.33% - 1rem);
+  flex: calc(33.33% - 1rem);
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  margin-right: 1.5rem;
+}
+
+@media (min-width: 991px) {
+  .episode-grid .post-entry:nth-of-type(3n) {
+    margin-right: 0;
+  }
+}
+
+@media (max-width: 990px) {
+  .episode-grid .post-entry {
+    max-width: calc(50% - 0.75rem); /* 2 Column */
+    -ms-flex: calc(50% - 0.75rem);
+    flex: calc(50% - 0.75rem);
+  }
+
+  .episode-grid .post-entry:nth-of-type(2n) {
+    margin-right: 0;
+  }
+}
+
+@media (max-width: 414px) {
+  .episode-grid .post-entry {
+    max-width: 100%; /* 1 Column */
+    -ms-flex: 100%;
+    flex: 100%;
+    margin-right: 0;
+    padding: 1.5rem;
+  }
+}
+
 /* User Logos */
 .user-logos-container {
   display: flex;

--- a/broadcast/index.md
+++ b/broadcast/index.md
@@ -5,11 +5,10 @@ show_hero: true
 ---
 
 <div class="container container__broadcast">
+<div class="row spacer-60">
+<div markdown="1" class="col-lg-8">
 
-  <div class="row spacer-60">
-    <div class="col-md-12">
-
-<div markdown="1" class="leftcol widecol">
+## About
 
 With great data comes even greater access latency. Welcome to the Trino
 Community Broadcast where we transform your latency woes to fast insights. Trino
@@ -25,27 +24,97 @@ directly on Slack or Twitter.
 
 See us live every two weeks!
 
-
-<a class="button" href="/broadcast/episodes.html">See past episodes!</a>
+</div>
+<div markdown="1" class="col-lg-3">
 
 ## Co-hosts
 
- - Brian Olsen [@bitsondatadev](https://twitter.com/bitsondatadev)
- - Manfred Moser [@simpligility](https://twitter.com/simpligility)
+- Brian Olsen [@bitsondatadev](https://twitter.com/bitsondatadev)
+- Manfred Moser [@simpligility](https://twitter.com/simpligility)
 
-## Where to watch or listen
+## Watch or listen
 
- - Watch live on <a href="https://www.twitch.tv/trinodb" target="_blank">Trino Twitch</a>
- - Watch later on <a href="https://www.youtube.com/playlist?list=PLFnr63che7war_NzC7CJQjFuUKLYC7nYh" target="_blank">Youtube playlist</a>
- - Listen on <a href="https://podcasts.apple.com/us/podcast/trino-community-broadcast/id1533484786" target="_blank">Apple podcast</a>
- - Listen on <a href="https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5idXp6c3Byb3V0LmNvbS8xMzc0NTMyLnJzcw==" target="_blank">Google podcast</a>
- - Listen on <a href="https://open.spotify.com/show/53ZrVCCmZSsEmvlNfzpWSL" target="_blank">Spotify</a>
-
-# Upcoming shows
-
-<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23dd00a1&amp;ctz=America%2FDetroit&amp;src=NDhibXJvaXVpZmg2NWJsZWNhOGxzNGhyNTRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23D81B60&amp;mode=MONTH&amp;showCalendars=0&amp;showTz=1&amp;showTabs=1&amp;showPrint=0" style="border:solid 1px #777" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+- Watch:
+<a href="https://www.youtube.com/playlist?list=PLFnr63che7war_NzC7CJQjFuUKLYC7nYh" target="_blank">
+  <i class="fab fa-youtube watch-listen-icon" title="Youtube"></i>
+</a>
+<a href="https://www.twitch.tv/trinodb" target="_blank">
+  <i class="fab fa-twitch watch-listen-icon" title="Twitch"></i>
+</a>
+- Listen:
+<a href="https://podcasts.apple.com/us/podcast/trino-community-broadcast/id1533484786" target="_blank">
+  <i class="fab fa-apple watch-listen-icon" title="Apple"></i>
+</a>
+<a href="https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5idXp6c3Byb3V0LmNvbS8xMzc0NTMyLnJzcw==" target="_blank">
+  <i class="fab fa-google watch-listen-icon" title="Google"></i>
+</a>
+<a href="https://open.spotify.com/show/53ZrVCCmZSsEmvlNfzpWSL" target="_blank">
+  <i class="fab fa-spotify watch-listen-icon" title="Spotify"></i>
+</a>
+- <a href="{{ '/broadcast/feed.xml' | relative_url }}">Subscribe via RSS</a>
 
 </div>
+<div markdown="1" class="col-md-12">
+
+## Upcoming shows
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23dd00a1&amp;ctz=America%2FDetroit&amp;src=NDhibXJvaXVpZmg2NWJsZWNhOGxzNGhyNTRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23D81B60&amp;mode=AGENDA&amp;showCalendars=0&amp;showTz=1&amp;showTabs=0&amp;showPrint=0" style="border:solid 1px #777; margin-bottom: 2rem;" width="100%" height="240" frameborder="0" scrolling="no"></iframe>
+
+## Latest episode
+
+{% assign latestEpisode =  site.episodes | last %}
+
+<div class="post-entry card latest-entry">
+  <div class="d-flex flex-column-reverse flex-lg-row justify-content-between">
+    <div class="latest-entry-text-container">
+      <h3><a class="post-link" href="{{ episode.url | relative_url }}">{{ latestEpisode.title | escape }}</a></h3>
+      <span class="post-meta">{{ latestEpisode.date | date: "%b %-d, %Y" }}</span>
+      <ul>
+        {% for section in latestEpisode.sections %}
+        <li>
+            {{section.title}}:
+            <a href="https://www.youtube.com/watch?v={{ latestEpisode.youtube_id}}&t={{ section.time }}s" target="_blank">
+            {{ section.desc }}
+            </a>
+        </li>
+        {% endfor %}
+      </ul>
+      <a href="{{ site.baseurl }}{{ latestEpisode.url }}" style="margin-top: auto;">Listen, watch, or read the show notes...</a>
+    </div>
+    <div class="latest-entry-video-container">
+        <div class="latest-entry-video-wrapper">
+          <iframe src="https://www.youtube.com/embed/{{ latestEpisode.youtube_id }}" frameborder="0" allowfullscreen></iframe>
+        </div>
+    </div>
+  </div>
+</div>
+
+<div markdown="1" class="previous-episode-header">
+
+## Previous episodes
+
+<a href="/broadcast/episodes.html">See all episodes</a>
+</div>
+<div class="episode-grid">
+{% for episode in site.episodes reversed offset:1 limit:9 %}
+  <div class="post-entry card">
+    <h5><a class="post-link" href="{{ episode.url | relative_url }}">{{ episode.title | escape }}</a></h5>
+    <span class="post-meta">{{ episode.date | date: "%b %-d, %Y" }}</span>
+    <ul>
+      {% for section in episode.sections limit:3 %}
+      <li>
+          {{section.title}}:
+          <a href="https://www.youtube.com/watch?v={{ episode.youtube_id}}&t={{ section.time }}s" target="_blank">
+          {{ section.desc }}
+          </a>
+      </li>
+      {% endfor %}
+    </ul>
+    <a href="{{ site.baseurl }}{{ episode.url }}">Listen, watch, or read the show notes...</a>
+  </div>
+{% endfor %}
+</div>
+
 </div>
 </div>
 </div>


### PR DESCRIPTION
This PR updates the layout of the Community Broadcast page.

These changes were initially discussed on [Slack]( https://trinodb.slack.com/archives/C01GW0QR16Z/p1613595522041100) and were further materialized via discussion with @bitsondatadev 

One of the goals is to highlight more of the podcast content, as opposed to having to click the current "See Past Episodes" button.

Included:
- Call out 'Latest Episode' and embed video
- Grid/Blog style for previous episodes
- Watch/Listen links are now icons
- Google Calendar now just displays the 'Agenda' 
- Previous episode cards are limited to 3 bulleted items

Related Slack Thread: https://trinodb.slack.com/archives/C01GW0QR16Z/p1613595522041100
