### PR TITLE
Safari fix for border on outline-card

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -136,6 +136,11 @@ footer .footer-copyright {font-size: 0.7rem;}
     visibility: hidden;
     pointer-events: none;
   }
+
+  .outline-card h3::before {
+    padding-top: initial;
+    margin-top: initial;
+  }
 }
 
 /*----- TOC STYLES -----*/


### PR DESCRIPTION
This PR contains a fix for the border size on `.outline-card`'s

<details><summary>Snapshots</summary>

#### Before: 

![image_from_ios](https://user-images.githubusercontent.com/1330423/110349052-4c191680-8000-11eb-901e-9cdb3d7be1a9.jpg)

#### After:

![Screen Shot 2021-03-08 at 11 20 50 AM](https://user-images.githubusercontent.com/1330423/110349113-5d622300-8000-11eb-91c3-db6a1b56c1ba.png)

</details>
