### PR TITLE
Add margin to pre code blocks

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -257,7 +257,8 @@ pre {
   background: whitesmoke;
   outline: 1px solid lightgray;
   padding: 10px;
-  margin: 5px; }
+  margin: 1rem 0.5rem;
+}
 
 code.language-plaintext {
   background-color: whitesmoke;


### PR DESCRIPTION
This PR adds some breathing room to the `pre` code blocks for better readability. 

<details>
<summary>snapshots</summary>

| old | new |
| ---- | ---- |
|   <img width="925" alt="Screen Shot 2021-03-31 at 9 24 53 AM" src="https://user-images.githubusercontent.com/1330423/113151735-627f5000-9203-11eb-8ed3-9d094fc915cc.png">   |   <img width="907" alt="Screen Shot 2021-03-31 at 9 25 22 AM" src="https://user-images.githubusercontent.com/1330423/113151751-67dc9a80-9203-11eb-9a27-65dee53dad60.png">   | 

</details>