### PR TITLE
Replace presto-client-ruby by trino-client-ruby

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -45,7 +45,7 @@ programming languages, and programs using the related platform:
 * [trino-python-client]({{site.github_org_url}}/trino-python-client) for Python
 * [PyHive](https://github.com/dropbox/PyHive) for Python
 * [RPresto](https://github.com/prestodb/RPresto) for R
-* [presto-client-ruby](https://github.com/treasure-data/presto-client-ruby) for Ruby
+* [trino-client-ruby](https://github.com/treasure-data/trino-client-ruby) for Ruby
 
 </div></div>
 


### PR DESCRIPTION
presto-client-ruby has been migrated to trino-client-ruby

- https://github.com/treasure-data/trino-client-ruby
- https://rubygems.org/gems/trino-client