### PR TITLE
Using Logo Trino-ko-tiny in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # trino.io
 
+<img alt="Trino Logo" src="./assets/images/trino-logo/trino-ko_tiny-alt.svg" width="15%" align="right" />
+
 The source for the Trino community website available at
 [https://trino.io/](https://trino.io/).
 


### PR DESCRIPTION
Using logo trino-ko-tiny in readme  file made looks nicer

<strong>Before</strong>
![image](https://user-images.githubusercontent.com/31585789/135741997-7c18e88a-8638-4922-b642-491e0b7d1164.png)

<strong>After</strong>
![image](https://user-images.githubusercontent.com/31585789/135742011-0cf6d6fb-c9ab-4d23-8e43-d8d4f4fba4bf.png)
