### PR TITLE
Update Slack invite link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ exclude:
 
 trino_version: 372
 conduct_email: conduct@trino.io
-slack_join: "https://join.slack.com/t/trinodb/shared_invite/zt-sbw8lqer-DL3zksjpm6fyIsSQz74MBA"
+slack_join: "https://join.slack.com/t/trinodb/shared_invite/zt-14ukl212d-98J09w~zC3vAQCgm6I2IxQ"
 slack_fqdn: trinodb.slack.com
 github_org_url: "https://github.com/trinodb"
 github_repo_url: "https://github.com/trinodb/trino"


### PR DESCRIPTION
The old link became inactive

Fixes: https://github.com/trinodb/trino/issues/11355