### PR TITLE
Add blog announcing 2022 Trino summit

### DIFF
--- a/_posts/2022-06-30-trino-summit-call-for-speakers.md
+++ b/_posts/2022-06-30-trino-summit-call-for-speakers.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: "Announcing the 2022 Trino Summit"
+author: "Cole Bowden"
+excerpt_separator: <!--more-->
+---
+
+We are pleased to announce the upcoming 2022 Trino Summit. The summit is
+scheduled as *hybrid* event on the 10th of November 2022, and attendance is
+free! You will be able to join us online, or you can make the trip to San
+Francisco and meet us at the Commonwealth Club on the downtown waterfront.
+Please be aware that spots at the live event are limited, so register soon if
+you want to attend. Please also be aware that you need to register regardless of
+whether you'll be joining us in-person or online.
+
+<div class="card-deck spacer-30">
+    <a class="btn btn-pink" href="https://www.starburst.io/info/trinosummit/">
+        Register to attend
+    </a>
+    <a class="btn btn-orange" href="https://sessionize.com/trino-summit-2022/">
+        Sign up to speak
+    </a>
+</div>
+<div class="spacer-30"></div>
+
+Starburst is the lead sponsor for the summit, but they welcome other sponsors to
+help make this a successful event for the Trino community. If that interests you
+or your employer, you should [contact the Starburst team for more information.](mailto:events@starburst.io)
+
+<!--more-->
+
+If you'd like to share your knowledge and information about Trino usage and give
+a talk at this year's Trino Summit, we're putting out a call for speakers. We
+will be accepting submissions from now until September 15th, but we recommend
+submitting soon, because slots are filling up fast.
+
+We're looking for intermediate to advanced-level talks on a variety of themes.
+If you have an interesting story about how you were able to leverage Trino,
+found a neat way to extend it with a custom plugin, or swapped to Trino for a
+performance win, we'd love to hear about it. We're excited to expand our speaker
+lineup with talks from the broader Trino community. If you're interested, you
+can check out the speaker registration page for more information.
+
+And of course, we're looking forward to seeing you there, whether in-person or
+online!


### PR DESCRIPTION
Blog post to announce the 2022 Trino summit and call for speakers/talks at the event.