### PR TITLE
Fix link to Meetup pages

### DIFF
--- a/community.md
+++ b/community.md
@@ -76,7 +76,7 @@ title: Trino Community
           </div>
         </a>
         <div class="events-thirds-container">
-          <a href="https://www.meetup.com/topics/trino/" class="event-third-block"></a>
+          <a href="https://www.meetup.com/pro/trino-community/" class="event-third-block"></a>
           <a href="https://twitter.com/trinodb" class="event-third-block">
             <div>Follow us<h2>@trinodb</h2></div>
             <img src="../assets/images/community/twitter.png" alt="@trinodb on Twitter" />


### PR DESCRIPTION
- old link does not work when browser location is disabled
- from old link search on meetup is hard to use/unusable
- new link goes to nice overview page of all groups