### PR TITLE
Remove mention of pyhive

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -43,7 +43,6 @@ programming languages, and programs using the related platform:
 * [lento](https://github.com/vweevers/lento) for Node.js
 * [dbt adapter](https://github.com/starburstdata/dbt-trino)
 * [trino-python-client]({{site.github_org_url}}/trino-python-client) for Python
-* [PyHive](https://github.com/dropbox/PyHive) for Python
 * [RPresto](https://github.com/prestodb/RPresto) for R
 * [trino-client-ruby](https://github.com/treasure-data/trino-client-ruby) for Ruby
 


### PR DESCRIPTION
- users should not be misled to use it, trino-python-client is the much better solution