### PR TITLE
Remove infrastructure channel from Slack page

### DIFF
--- a/slack.md
+++ b/slack.md
@@ -34,7 +34,6 @@ available for help.
 * [#dev](https://{{site.slack_fqdn}}/archives/CP1MUNEUX) - discussions about Trino codebase, development, and developing extensions
 * [#triage](https://{{site.slack_fqdn}}/messages/CFP4810CV) - discussions and coordination about new issues and PRs from the community
 * [#releases](https://{{site.slack_fqdn}}/messages/CFP480UKX) - notices about upcoming releases
-* [#infrastructure](https://{{site.slack_fqdn}}/messages/CFPVDC9JT) - discussions about project infrastructure (Travis, Github, Maven, etc.)
 * [#github](https://{{site.slack_fqdn}}/messages/CFN644R4G) - feed of activity on [GitHub]({{site.github_org_url}})
 * [#documentation](https://{{site.slack_fqdn}}/messages/C01TEP0HJTH) - discuss [Trino documentation]({{site.url}}/docs/current/)
 


### PR DESCRIPTION
The channel was archived in October 2021.