### PR TITLE
Replace birthday banner with Trino summit banner

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,11 +21,12 @@ title: Distributed SQL query engine for big data
   </div>
 </div>
 
-<div class="trino-birthday-banner">
-  <div class="trino-birthday-content">
-    <h1>Trino is celebrating its 10th Birthday!</h1>
-    <a class="btn trino-birthday-button" href="{{ site.url }}{% post_url 2022-08-08-trino-tenth-birthday %}">Learn more</a>
-    <img src="./assets/images/trino-birthday-banner-peek.png" class="trino-birthday-peek">
+<div class="trino-summit-banner">
+  <div class="trino-summit-content">
+    <img src="/assets/images/trino-summit-logo.png" class="trino-summit-logo" />
+    <h3>November 10th, 2022</h3>
+    <a class="btn trino-summit-button" href="https://www.starburst.io/info/trinosummit/" target="_blank">Register</a>
+    <img src="/assets/images/trino-summit-banner-peek.png" class="trino-summit-peek">
   </div>
 </div>
 


### PR DESCRIPTION
Updates the banner to link to the Trino summit instead of the birthday celebration page. Just reusing the banner from #220 

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/104291808/190826693-cedb8324-3c08-4e4c-9d79-14182bdfabd2.png">

https://deploy-preview-346--trino.netlify.app/