### PR TITLE
Fix wrapping on various pages

### DIFF
--- a/development/process.md
+++ b/development/process.md
@@ -14,38 +14,44 @@ show_hero: true
 <div markdown="1" class="leftcol widecol process">
 
 
-This is the process we suggest for contributions.  This process is designed to reduce the burden on project 
-reviewers, impact on other contributors, and to keep the amount of rework from the contributor to a minimum.
+This is the process we suggest for contributions.  This process is designed to
+reduce the burden on project reviewers, impact on other contributors, and to
+keep the amount of rework from the contributor to a minimum.
 
 1. Sign the [contributor license agreement]({{site.github_org_url}}/cla).
 
-2. Start a discussion by creating a Github [issue]({{site.github_repo_url}}/issues), or asking on
-   [Slack](/slack.html) (unless the change is trivial).
+2. Start a discussion by creating a Github
+   [issue]({{site.github_repo_url}}/issues), or asking on [Slack](/slack.html)
+   (unless the change is trivial).
 
     1. This step helps you identify possible collaborators and reviewers.
     2. Does the change align with technical vision and project values?
-    3. Will the change conflict with another change in progress? If so, work with others to minimize impact.
-    4. Is this change large?  If so, work with others to break into smaller steps.
+    3. Will the change conflict with another change in progress? If so, work
+       with others to minimize impact.
+    4. Is this change large?  If so, work with others to break into smaller
+       steps.
 
 3. Implement the change
 
-    1. If the change is large, post a preview Github [pull request]({{site.github_repo_url}}/pulls)
-       with the title prefixed with `[WIP]`, and share with collaborators.
+    1. If the change is large, post a preview Github
+       [pull request]({{site.github_repo_url}}/pulls) with the title prefixed
+       with `[WIP]`, and share with collaborators.
     2. Include tests and documentation as necessary.
 
 4. Create a Github [pull request]({{site.github_repo_url}}/pulls) (PR).
 
     1. Make sure the pull request passes the tests in CI.
-    2. If known, request a review from an expert in the area changed.  If unknown, ask for help on [Slack](/slack.html).
+    2. If known, request a review from an expert in the area changed. If
+       unknown, ask for help on [Slack](/slack.html).
 
-    There are some tests that use external services, like Google BigQuery, and require
-    additional credentials. The Trino project cannot share these credentials with
-    contributors, so it runs these tests in its CI workflows only on branches in the
-    Trino repository, not in contributor forks.
+    There are some tests that use external services, like Google BigQuery, and 
+    require additional credentials. The Trino project cannot share these
+    credentials with contributors, so it runs these tests in its CI workflows
+    only on branches in the Trino repository, not in contributor forks.
 
-    Trino maintainers, so project members with write access to the repository, can
-    schedule additional workflow runs after reviewing a PR by adding a comment
-    starting with this line:
+    Trino maintainers, so project members with write access to the repository,
+    can schedule additional workflow runs after reviewing a PR by adding a
+    comment starting with this line:
 
     ```
     /test-with-secrets sha=<all-40-characters>
@@ -56,17 +62,21 @@ reviewers, impact on other contributors, and to keep the amount of rework from t
 
 5. Review is performed by one or more reviewers.
 
-    1. This normally happens within a few days, but may take longer if the change is large, complex, or if a
-       critical reviewer is unavailable. (feel free to ping the reviewer on the pull request).
+    1. This normally happens within a few days, but may take longer if the
+       change is large, complex, or if a critical reviewer is unavailable. (feel
+       free to ping the reviewer on the pull request).
 
 6. Address concerns and update the pull request.
 
-    1. Comments are addressed to each individual commit in the pull request, and changes should be addressed in a
-       new [`fixup!` commit](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt) placed after each commit.
-       This is to make it easier for the reviewer to see what was updated.
-    2. After pushing the changes, add a comment to the pull-request, mentioning the reviewers by name, stating that
-       the review comments have been addressed.  This is the only way that a reviewer is notified that you are ready
-       for the code to be reviewed again.
+    1. Comments are addressed to each individual commit in the pull request, and
+       changes should be addressed in a new
+       [`fixup!` commit](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---fixupamendrewordltcommitgt)
+       placed after each commit. This is to make it easier for the reviewer to
+       see what was updated.
+    2. After pushing the changes, add a comment to the pull-request, mentioning
+       the reviewers by name, stating that the review comments have been
+       addressed. This is the only way that a reviewer is notified that you are
+       ready for the code to be reviewed again.
     3. Go to step 5.
 
 7. Maintainer merges the pull request after final changes are accepted.

--- a/development/roles.md
+++ b/development/roles.md
@@ -14,26 +14,33 @@ show_hero: true
 
 ## Overview
 
-Everyone is encouraged to participate in the Trino project. Anyone can influence the project by simply being
-involved in the discussions about new features, the roadmap, architecture, and even problems they are facing.
-The various roles described here do not carry more weight in these discussions, and instead we try to always
-work towards consensus. The Trino project has a strong [vision and development philosophy](vision.html)
-which helps to guide discussions and normally allows us to reach consensus. When we can't come to consensus,
-we work to figure out what we agree on, and what we don't. Then we move forward by building what we agree on,
-which helps everyone better understand the parts we don't agree on, and hopefully builds empathy at the same time.
+Everyone is encouraged to participate in the Trino project. Anyone can influence 
+the project by simply being involved in the discussions about new features, the
+roadmap, architecture, and even problems they are facing. The various roles
+described here do not carry more weight in these discussions, and instead we try
+to always work towards consensus. The Trino project has a strong
+[vision and development philosophy](vision.html) which helps to guide
+discussions and normally allows us to reach consensus. When we can't come to
+consensus, we work to figure out what we agree on, and what we don't. Then we
+move forward by building what we agree on, which helps everyone better
+understand the parts we don't agree on, and hopefully builds empathy at the same
+time.
 
 The following describes the expectations and duties of the various roles.
 
 ## Participants
 
-This is the most important role. Very simply put, participants are those who show up and join in discussions
-about the project. Users, developers, and administrators can all be participants, as can literally anyone who
-has the time, energy, and passion to become involved. Participants suggest improvements and new features. They
-report bugs, regressions, performance issues, and so on. They work to make Trino better for everyone.
+This is the most important role. Very simply put, participants are those who
+show up and join in discussions about the project. Users, developers, and
+administrators can all be participants, as can literally anyone who has the
+time, energy, and passion to become involved. Participants suggest improvements
+and new features. They report bugs, regressions, performance issues, and so on.
+They work to make Trino better for everyone.
 
 **Expectations and duties:**
 
-* Be involved in discussions about features, roadmaps, architecture, and long-term plans.
+* Be involved in discussions about features, roadmaps, architecture, and
+  long-term plans.
 * Help other users on the mailing list, on GitHub issues, and on Slack.
 * Propose and discuss new features and improvements.
 * Help raise the project's quality bar.
@@ -41,85 +48,106 @@ report bugs, regressions, performance issues, and so on. They work to make Trino
 * Report bugs and performance regressions.
 * Suggest improvements to infrastructure and testing.
 * Recommend improvements to documentation and the website.
-* Understand that although English is the language of this project, English is not the first language of
-  many participants. Assume positive intent from others and realize that negative sounding comments are
-  often unintentional due to language barriers.
+* Understand that although English is the language of this project, English is
+  not the first language of many participants. Assume positive intent from
+  others and realize that negative sounding comments are often unintentional due
+  to language barriers.
 
 
 ## Contributors
 
-A contributor submits changes to Trino. The full contribution process is described [here](process.html).
+A contributor submits changes to Trino. The full contribution process is 
+described [here](process.html).
 
 **Expectations and duties:**
 
-* Be empathetic to the reviewers. Reviewing a change can be hard work and time consuming.
+* Be empathetic to the reviewers. Reviewing a change can be hard work and time
+  consuming.
 * Keep commits small when possible and provide reasoning and context when
   submitting changes. Reviews go smoother if you make the reviewer’s job easier.
-* Be responsive when changes are requested by the reviewer. It is easier to re-review the modified changes
-  if they are completed shortly after original review.
+* Be responsive when changes are requested by the reviewer. It is easier to
+  re-review the modified changes if they are completed shortly after original
+  review.
 * Ask for clarification if you are confused by a suggested change.
 * Speak up if your contribution appears to be stuck.
 * Read the project vision and development philosophy.
-* Follow the style guidelines and more importantly, follow the Trino coding conventions by matching your
-  code to the existing code. Keep in mind the Trino development philosophy is to have all code appear as
-  if it were written by a single person.
+* Follow the style guidelines and more importantly, follow the Trino coding
+  conventions by matching your code to the existing code. Keep in mind the Trino
+  development philosophy is to have all code appear as if it were written by a
+  single person.
 * Sign the contributor license agreement (CLA).
 
 ## Reviewers
 
-A reviewer reads a proposed change to Trino, and assesses how well the change aligns with the Trino vision
-and guidelines. This includes everything from high level project vision to low level code style. Everyone
-is invited and encouraged to review others' contributions -- you don't need to be a maintainer for that.
+A reviewer reads a proposed change to Trino, and assesses how well the change
+aligns with the Trino vision and guidelines. This includes everything from high
+level project vision to low level code style. Everyone is invited and encouraged
+to review others' contributions -- you don't need to be a maintainer for that.
 
 **Expectations and duties:**
 
-* Be empathetic to contributors. They may have put a lot of effort into the proposed change and may
-  not be familiar with the codebase, the process, or the history of the project.
+* Be empathetic to contributors. They may have put a lot of effort into the
+  proposed change and may not be familiar with the codebase, the process, or the
+  history of the project.
 * Be responsive to questions.
 * Re-review after suggested changes have been applied.
-* Be clear about which changes are only suggestions, and which changes are necessary.
-* Let the contributor know what is going on, so reviews don't appear to be stuck.
-* Raise a discussion when a change does not seem to align with the vision or development philosophy.
+* Be clear about which changes are only suggestions, and which changes are
+  necessary.
+* Let the contributor know what is going on, so reviews don't appear to be
+  stuck.
+* Raise a discussion when a change does not seem to align with the vision or
+  development philosophy.
 * Point out deviations from the code conventions and style guidelines.
 * Ask for help reviewing areas you don't understand.
 
 ## Maintainer
 
-In Trino, maintainer is an active job. A maintainer is responsible for checking in code only after ensuring
-it has been reviewed thoroughly and aligns with the Trino vision and guidelines. In addition to merging code,
-a maintainer actively participates in discussions and reviews. Being a maintainer does not grant additional rights
-in the project to make changes, set direction, or anything else that does not align with the direction of the
-project. Instead, a maintainer is expected to bring these to the project participants as needed to gain consensus.
-The maintainer role is for an individual, so if a maintainer changes employers, the role is retained. However,
-if a maintainer is no longer actively involved in the project, their maintainer status will be reviewed.
+In Trino, maintainer is an active job. A maintainer is responsible for checking 
+in code only after ensuring it has been reviewed thoroughly and aligns with the
+Trino vision and guidelines. In addition to merging code, a maintainer actively
+participates in discussions and reviews. Being a maintainer does not grant
+additional rights in the project to make changes, set direction, or anything
+else that does not align with the direction of the project. Instead, a
+maintainer is expected to bring these to the project participants as needed to
+gain consensus. The maintainer role is for an individual, so if a maintainer
+changes employers, the role is retained. However, if a maintainer is no longer
+actively involved in the project, their maintainer status will be reviewed.
 
 **Expectations and duties:**
 
 * Be an active reviewer and participant.
-* Know which changes are likely to be controversial, and work to resolve the controversy as early as possible.
+* Know which changes are likely to be controversial, and work to resolve the
+  controversy as early as possible.
 * Know when a change needs more reviewers involved.
 * Ensure the review of a proposed change is thorough.
 * Point out when a contribution appears to be stuck.
 * Update release notes when committing changes.
 * Follow the CLA and IP policies.
 
-An Apache Hive committer did an excellent write up on their process and much of this aligns with our philosophy
-on maintainers. [Read about it](https://cwiki.apache.org/confluence/display/Hive/BecomingACommitter).
+An Apache Hive committer did an excellent write up on their process and much of
+this aligns with our philosophy on maintainers.
+[Read about it](https://cwiki.apache.org/confluence/display/Hive/BecomingACommitter).
 
 ## Path to becoming a maintainer
 
-1. **Read:** Understand the project values and scope, the development philosophy and guidelines, and the change
-   process. These contain necessary background information to be successful in Trino.
-2. **Contribute:** This helps you learn the codebase, and understand the development process. Start with
-   something small to become familiar with the process.
-3. **Review:** Once you become familiar with a part of Trino, start reviewing proposed changes to that part.
-   A maintainer does an additional final review, and this helps you understand what you are missing in your
-   reviews. At some point, your first pass reviews will not require additional changes during the final review.
-4. **Maintainer:** The next step is to demonstrate an understanding of what you know and don’t know. It is common
-   for changes to require reviews from multiple people, since no one person is familiar with all of Trino. We
-   are also looking for an understanding of the project values and technical vision. Being a maintainer means
-   reviewing and merging code in your areas of expertise from all contributors. The maintainer role is retained while
-   being active in the project.
+1. **Read:** Understand the project values and scope, the development philosophy
+   and guidelines, and the change process. These contain necessary background
+   information to be successful in Trino.
+2. **Contribute:** This helps you learn the codebase, and understand the
+   development process. Start with something small to become familiar with the
+   process.
+3. **Review:** Once you become familiar with a part of Trino, start reviewing
+   proposed changes to that part. A maintainer does an additional final review,
+   and this helps you understand what you are missing in your reviews. At some
+   point, your first pass reviews will not require additional changes during the
+   final review.
+4. **Maintainer:** The next step is to demonstrate an understanding of what you
+   know and don’t know. It is common for changes to require reviews from
+   multiple people, since no one person is familiar with all of Trino. We are
+   also looking for an understanding of the project values and technical vision.
+   Being a maintainer means reviewing and merging code in your areas of
+   expertise from all contributors. The maintainer role is retained while being
+   active in the project.
 
 </div>
 </div>

--- a/development/vision.md
+++ b/development/vision.md
@@ -16,109 +16,125 @@ show_hero: true
 ## Project values
 
 Correct
-: Trino is used for critical decisions (e.g., financial results for public markets), and results
-  must always be correct.
+: Trino is used for critical decisions (e.g., financial results for public
+  markets), and results must always be correct.
 
 Secure
-: Trino is a gateway to sensitive information, and must protect that information.
+: Trino is a gateway to sensitive information, and must protect that
+  information.
 
 Long Term
-: We expect that Trino will be used for at least the next 20 years.  We build for the long term.
+: We expect that Trino will be used for at least the next 20 years.  We build
+  for the long term.
 
 Standards-based
-: These can be formal standards like ANSI SQL, JDBC or ODBC, or implicit conventions of industry
-  standard databases. This makes it easier for users and integrators, because their existing 
-  skills transfer.
+: These can be formal standards like ANSI SQL, JDBC or ODBC, or implicit
+  conventions of industry standard databases. This makes it easier for users and
+  integrators, because their existing skills transfer.
 
 Just works
-: Simple to get started.  Trino should just work out of the box and provide good performance with
-  minimal setup. Trino is a large complex system, so simplification makes everything better.
+: Simple to get started.  Trino should just work out of the box and provide good
+  performance with minimal setup. Trino is a large complex system, so
+  simplification makes everything better.
 
 Supported
-: Everything that ships with Trino is supported.  This means that features that cannot be tested
-  and supported are not added, e.g., PowerPC support is only being added now that test hardware
-  is available.
+: Everything that ships with Trino is supported.  This means that features that
+  cannot be tested and supported are not added, e.g., PowerPC support is only
+  being added now that test hardware is available.
 
 Real world uses
-: Trino is designed and tuned for real world workloads over synthetic benchmarks.
+: Trino is designed and tuned for real world workloads over synthetic
+  benchmarks.
 
 Commercially friendly
-: We encourage enterprises to use Trino for their analytics needs, and we encourage vendors to
-  base products on Trino.  We appreciate contributions back, but do not require them.
+: We encourage enterprises to use Trino for their analytics needs, and we
+  encourage vendors to base products on Trino.  We appreciate contributions
+  back, but do not require them.
 
 ## What Trino is, and is not
 
 A server
-: Trino is a standalone server, and only provides libraries for external applications to connect
-  to Trino (e.g., JDBC, Python, etc).  Specifically, the internal details such as the parser,
-  planner, analyzer, optimizer, etc., are not public APIs, and are not supported as libraries.
+: Trino is a standalone server, and only provides libraries for external
+  applications to connect to Trino (e.g., JDBC, Python, etc).  Specifically, the
+  internal details such as the parser, planner, analyzer, optimizer, etc., are
+  not public APIs, and are not supported as libraries.
 
 For analytics
-: Trino is designed to perform queries over large segments of data, and is not designed for point
-  reads and updates of single rows of data (i.e. OLAP not OLTP).
+: Trino is designed to perform queries over large segments of data, and is not
+  designed for point reads and updates of single rows of data (i.e. OLAP not
+  OLTP).
 
 Big analytics
-: Trino is designed to process queries that are large with respect to the resources available and
-  quality of service.  This includes traditional large long running batch workloads, but also
-  includes workloads that must be done quickly or with limited resources.
+: Trino is designed to process queries that are large with respect to the
+  resources available and quality of service.  This includes traditional large
+  long running batch workloads, but also includes workloads that must be done
+  quickly or with limited resources.
 
 Distributed system
-: Trino is designed for computations across many networked computers.  It is not designed for
-  single computer installations. If your analytics can be executed on a single computer, there
-  are many other excellent solutions available.
+: Trino is designed for computations across many networked computers. It is not
+  designed for single computer installations. If your analytics can be executed
+  on a single computer, there are many other excellent solutions available.
 
 Trusted
-: Trino performs authentication and authorization of requests, and therefore is assumed to be
-  a trusted environment.
+: Trino performs authentication and authorization of requests, and therefore is
+  assumed to be a trusted environment.
 
 ## Development philosophy
 
 Opinionated software
-: There are many ways to develop software; this is the way that works for this specific project.
+: There are many ways to develop software; this is the way that works for this
+  specific project.
 
 Guidelines, not rules
-: We believe in having good programmers, who make high quality, thoughtful, decisions, not those
-  that just follow rules, because rules need to be broken from time to time.
+: We believe in having good programmers, who make high quality, thoughtful,
+  decisions, not those that just follow rules, because rules need to be broken
+  from time to time.
 
 Readability
-: Our code is written for the readability of the next person. This takes longer, but eases 
-  maintenance and improvements over the long term.
+: Our code is written for the readability of the next person. This takes longer,
+  but eases maintenance and improvements over the long term.
 
 High quality
-: We have a high bar for changes, and carefully review each proposed change.  The change process
-  is optimized to reduce the burden on end-users, admins, and future maintainers, and not the 
-  productivity of the developer proposing the change.
+: We have a high bar for changes, and carefully review each proposed change. The
+  change process is optimized to reduce the burden on end-users, admins, and
+  future maintainers, and not the productivity of the developer proposing the
+  change.
 
 Meticulous
-: System-wide changes are carefully considered.  End user visible changes such as functions, 
-  language changes, connectors, etc., are carefully selected to provide a consistent user 
-  experience over the long term.  Library dependencies are carefully chosen based on quality, 
-  reliability, and impact on other dependencies. System wide abstractions are carefully designed
-  to ease the development of the entire system.  Expect any change of this type to be discussed
-  and considered at length.
+: System-wide changes are carefully considered.  End user visible changes such
+  as functions, language changes, connectors, etc., are carefully selected to
+  provide a consistent user experience over the long term.  Library dependencies
+  are carefully chosen based on quality, reliability, and impact on other
+  dependencies. System wide abstractions are carefully designed to ease the
+  development of the entire system.  Expect any change of this type to be
+  discussed and considered at length.
 
 Java software
-: Trino is written in Java, and takes advantage of modern Java features.  Standard Java build
-  tools, libraries and development environments are used to ease the on-boarding of developers.
+: Trino is written in Java, and takes advantage of modern Java features.
+  Standard Java build tools, libraries and development environments are used to
+  ease the on-boarding of developers.
 
 Complexity balance
-: There is a careful balance between the value a feature provides and the complexity introduced
-  to the system.  Similarly, the complexity of performance improvements must be justified by the
-  real world impact.  From the opposite side, real word requirements often necessitate complexity.
+: There is a careful balance between the value a feature provides and the
+  complexity introduced to the system.  Similarly, the complexity of performance
+  improvements must be justified by the real world impact.  From the opposite
+  side, real word requirements often necessitate complexity.
 
 Multiple use cases
-: Trino is designed for multiple use cases.  There are installations that exclusively run
-  multi-hour batch jobs, and others that run sub-second queries.  Some installations must be able
-  to share resources between interactive low latency queries and long running background queries.
-  Features cannot break one use case to better another case; all cases must be well supported in
-  one codebase.
+: Trino is designed for multiple use cases. There are installations that
+  exclusively run multi-hour batch jobs, and others that run sub-second queries.
+  Some installations must be able to share resources between interactive low
+  latency queries and long running background queries. Features cannot break one
+  use case to better another case; all cases must be well supported in one
+  codebase.
 
 Adaptation over configuration
-: As a complex multi-tenant query engine that executes arbitrary user defined computation, Trino
-  must be adaptive not only to different query characteristics, but also combinations of
-  characteristics. Without adaptiveness, it would be necessary to narrowly partition workloads and
-  tune configuration for each workload independently. That approach does not scale to the wide
-  variety of query shapes seen in production.
+: As a complex multi-tenant query engine that executes arbitrary user defined
+  computation, Trino must be adaptive not only to different query
+  characteristics, but also combinations of characteristics. Without
+  adaptiveness, it would be necessary to narrowly partition workloads and tune
+  configuration for each workload independently. That approach does not scale to
+  the wide variety of query shapes seen in production.
 
 </div>
 </div>

--- a/guidelines-corporate.md
+++ b/guidelines-corporate.md
@@ -3,44 +3,54 @@ layout: page
 title: Guidelines for participants with corporate interests
 ---
 
-The goal of the Trino community is to help all participants be successful in using Trino in their environment, and
-is specifically not for the promotion of any corporate interests including marketing, sales, recruiting, etc. There
-are cases where the goal of supporting the Trino community and promotion of corporate interests can overlap, and these
-guidelines are designed to help understand the line between the two.
+The goal of the Trino community is to help all participants be successful in
+using Trino in their environment, and is specifically not for the promotion of
+any corporate interests including marketing, sales, recruiting, etc. There are
+cases where the goal of supporting the Trino community and promotion of
+corporate interests can overlap, and these guidelines are designed to help
+understand the line between the two.
 
 ## Technical support
 
-For products that integrate with or extend Trino, we encourage the project owners to support Trino users asking for
-help with integration or extension. For long discussions about product-specific issues, we recommend that these be
-taken to an external forum dedicated to the product. If product support is commonly needed, we may create a separate
-group (e.g., Slack channel) to assist the community with the integration.
+For products that integrate with or extend Trino, we encourage the project
+owners to support Trino users asking for help with integration or extension. For
+long discussions about product-specific issues, we recommend that these be taken
+to an external forum dedicated to the product. If product support is commonly
+needed, we may create a separate group (e.g., Slack channel) to assist the
+community with the integration.
 
-Additionally, please restrict your responses to the questions being asked. Representatives from other vendors, while
-responding to a question, should not use that opportunity to nudge users to use a specific vendor’s offerings, unless
-the question relates specifically to a feature available in their product offering.
+Additionally, please restrict your responses to the questions being asked.
+Representatives from other vendors, while responding to a question, should not
+use that opportunity to nudge users to use a specific vendor’s offerings, unless
+the question relates specifically to a feature available in their product
+offering.
 
 ## Marketing
 
-Overtly selling products or services should be avoided (whether related or unrelated to Trino).
+Overtly selling products or services should be avoided (whether related or
+unrelated to Trino).
 
-The promotion of marketing materials with content that is very specific to a company’s products or services should not
-be shared in Trino community spaces. However, if a dedicated channel for supporting a product integration has been
-created, we encourage you to post informational announcements about releases, fixes, etc. relevant to the Trino
-community there.
+The promotion of marketing materials with content that is very specific to a
+company’s products or services should not be shared in Trino community spaces.
+However, if a dedicated channel for supporting a product integration has been
+created, we encourage you to post informational announcements about releases,
+fixes, etc. relevant to the Trino community there.
 
-While opinions about general technology and aspects of the big data ecosystem are welcome, opinions about any specific
-product offerings or features should be avoided when there is a conflict of interest.
+While opinions about general technology and aspects of the big data ecosystem
+are welcome, opinions about any specific product offerings or features should be
+avoided when there is a conflict of interest.
 
 ## Recruiting
 
-We encourage everyone to post information about Trino specific jobs, contracts, and internships to the `#jobs`
-Slack channel.
+We encourage everyone to post information about Trino specific jobs, contracts,
+and internships to the `#jobs` Slack channel.
 
 ## Features
 
-We encourage everyone to work on improving Trino, even when it eliminates the competitive advantage of a vendor. When
-discussing these projects it is expected that everyone operates in the best interests of the community, and does
-not block or even discourage work on such features for anti-competitive reasons.
+We encourage everyone to work on improving Trino, even when it eliminates the
+competitive advantage of a vendor. When discussing these projects it is expected
+that everyone operates in the best interests of the community, and does not
+block or even discourage work on such features for anti-competitive reasons.
 
 ## Questions
 

--- a/individual-code-of-conduct.md
+++ b/individual-code-of-conduct.md
@@ -3,56 +3,74 @@ layout: page
 title: Trino code of conduct
 ---
 
-Like the larger technical community, the Trino community is made up of a mixture of professionals and volunteers
-from all over the world, working on all aspect of Trino. We see this diversity as one of our huge strengths, because
-when people of diverse backgrounds come together to build a shared system, the result is better for everyone.
+Like the larger technical community, the Trino community is made up of a mixture
+of professionals and volunteers from all over the world, working on all aspect
+of Trino. We see this diversity as one of our huge strengths, because when
+people of diverse backgrounds come together to build a shared system, the result
+is better for everyone.
 
-This is why we encourage everyone, especially those with different perspectives, to communicate openly and frequently.
-To that end, we have a few ground rules that we ask people to adhere to. This code of conduct applies equally to all
+This is why we encourage everyone, especially those with different perspectives,
+to communicate openly and frequently. To that end, we have a few ground rules
+that we ask people to adhere to. This code of conduct applies equally to all
 participants in the Trino project.
 
-This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it’s intended - a
-guide to make communication easier and to benefit us all and the technical communities in which we participate.
+This isn’t an exhaustive list of things that you can’t do. Rather, take it in
+the spirit in which it’s intended - a guide to make communication easier and to
+benefit us all and the technical communities in which we participate.
 
-This code of conduct applies to all spaces managed by the Trino project or the Trino Software Foundation. This
-includes Slack, the mailing lists, the issue tracker, Trino events, and any other forums created by the project team,
-which the community uses for communication. In addition, violations of this code outside these spaces may affect a
-person's ability to participate within them.
+This code of conduct applies to all spaces managed by the Trino project or the
+Trino Software Foundation. This includes Slack, the mailing lists, the issue
+tracker, Trino events, and any other forums created by the project team, which
+the community uses for communication. In addition, violations of this code
+outside these spaces may affect a person's ability to participate within them.
 
-If you believe someone is violating the code of conduct, we ask that you report it by emailing `{{site.conduct_email}}`.
+If you believe someone is violating the code of conduct, we ask that you report
+it by emailing `{{site.conduct_email}}`.
 
 * **Be friendly and patient.**
-* **Be welcoming**. We strive to be a community that welcomes and supports people of all backgrounds and identities.
-This includes, but is not limited to, members of any race, ethnicity, culture, national origin, color, immigration
-status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age,
-size, family status, political belief, religion, and mental and physical ability.
-* **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any
-decision you take will affect users and colleagues, and you should take those consequences into account when making
-decisions. Remember that we are a world-wide community, so you might not be communicating in someone else's primary
-language.
-* **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor
-manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a
-personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a
-productive one. Members of the Trino community should be respectful when dealing with other members as well as with
-people outside the Trino community.
-* **Be careful in the words that you choose.** We are serious about the work we do, and we conduct ourselves
-professionally. Be kind to others. Do not insult or disparage other participants. Harassment and other exclusionary
-behavior aren't acceptable. This includes, but is not limited to:
+* **Be welcoming**. We strive to be a community that welcomes and supports
+  people of all backgrounds and identities. This includes, but is not limited
+  to, members of any race, ethnicity, culture, national origin, color,
+  immigration status, social and economic class, educational level, sex, sexual
+  orientation, gender identity and expression, age, size, family status,
+  political belief, religion, and mental and physical ability.
+* **Be considerate.** Your work will be used by other people, and you in turn
+  will depend on the work of others. Any decision you take will affect users and
+  colleagues, and you should take those consequences into account when making
+  decisions. Remember that we are a world-wide community, so you might not be
+  communicating in someone else's primary language.
+* **Be respectful.** Not all of us will agree all the time, but disagreement is
+  no excuse for poor behavior and poor manners. We might all experience some
+  frustration now and then, but we cannot allow that frustration to turn into a
+  personal attack. It’s important to remember that a community where people feel
+  uncomfortable or threatened is not a productive one. Members of the Trino
+  community should be respectful when dealing with other members as well as with
+  people outside the Trino community.
+* **Be careful in the words that you choose.** We are serious about the work we
+  do, and we conduct ourselves professionally. Be kind to others. Do not insult
+  or disparage other participants. Harassment and other exclusionary behavior
+  aren't acceptable. This includes, but is not limited to:
     * Violent threats or language directed against another person.
     * Discriminatory jokes and language.
     * Posting sexually explicit or violent material.
-    * Posting (or threatening to post) other people's personally identifying information ("doxing").
+    * Posting (or threatening to post) other people's personally identifying
+      information ("doxing").
     * Personal insults, especially those using racist or sexist terms.
     * Unwelcome sexual attention.
     * Advocating for, or encouraging, any of the above behavior.
-    * Repeated harassment of others. In general, if someone asks you to stop, then stop.
-* **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and Trino
-is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we are
-different. The strength of Trino comes from its varied community, people from a wide range of backgrounds. Different
-people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that
-they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on
-helping to resolve issues and learning from mistakes.
+    * Repeated harassment of others. In general, if someone asks you to stop,
+      then stop.
+* **When we disagree, try to understand why.** Disagreements, both social and
+  technical, happen all the time and Trino is no exception. It is important that
+  we resolve disagreements and differing views constructively. Remember that we
+  are different. The strength of Trino comes from its varied community, people
+  from a wide range of backgrounds. Different people have different perspectives
+  on issues. Being unable to understand why someone holds a viewpoint doesn’t
+  mean that they’re wrong. Don’t forget that it is human to err and blaming each
+  other doesn’t get us anywhere. Instead, focus on helping to resolve issues and
+  learning from mistakes.
 
-<sub><sup>_Original text courtesy of [Speak Up!](https://web.archive.org/web/20141109123859/http://speakup.io/coc.html)
+<sub><sup>_Original text courtesy of
+[Speak Up!](https://web.archive.org/web/20141109123859/http://speakup.io/coc.html)
 via [Django](https://www.djangoproject.com/conduct/) and licensed under
 [Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/)._</sup></sub>


### PR DESCRIPTION
A lot of markdown files have lines that go past the max line length they should have, which makes editing/reviewing them more cumbersome than it ideally should be. There's a few more edits coming down the line to these pages, so it's going to make life easier to fix the wrapping up front.

All of this should functionally be a no-op. No content is being changed, nor are there any edits being made.