### PR TITLE
Fix blank right margin on blog

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -40,7 +40,7 @@
   {% if content contains '<!-- Blog Index -->' %}
     {{ content }}
   {% else %}
-    <div class="row">
+    <div class="row" style="margin-left:0; margin-right:0;">
       <div class="col-md-8 col-sm-12">
         <div class="mx-2">
           {% include anchor_headings.html html=content anchorBody="#" %}


### PR DESCRIPTION
Before on mobile (pain, sadness, despair):
<img width="402" alt="image" src="https://user-images.githubusercontent.com/104291808/218206949-048917e7-9732-475d-b2f2-a0bd78fcae51.png">


After on mobile (happiness, joy, peace):
<img width="401" alt="image" src="https://user-images.githubusercontent.com/104291808/218206733-9d3c6c97-5294-490a-9650-97b01b45435c.png">

On desktop, both columns moved inwards 7 pixels, which does not make a difference.