### PR TITLE
Remove TOC from blog archive page

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -36,8 +36,8 @@
     </div>
   </div>
 
-  <!-- Avoids showing table of contents on blog index page -->
-  {% if content contains '<!-- Blog Index -->' %}
+  <!-- Comment to remove TOC from a page -->
+  {% if content contains '<!-- No TOC -->' %}
     {{ content }}
   {% else %}
     <div class="row" style="margin-left:0; margin-right:0;">

--- a/blog/archive.md
+++ b/blog/archive.md
@@ -5,6 +5,9 @@ title: Blog archives
 
 <div class="content container clearfix spacer-30">
 
+<!-- Ensures table of contents isn't displayed on this page, don't remove. -->
+<!-- No TOC -->
+
 <div class="row blog-page">
   <div class="col-12 text-surface-medium">
     <h2>{{ page.title}}</h2>

--- a/blog/index.html
+++ b/blog/index.html
@@ -6,7 +6,7 @@ title: Trino blog
 <div class="content container clearfix spacer-30">
 
 <!-- Ensures table of contents isn't displayed on this page, don't remove. -->
-<!-- Blog Index -->
+<!-- No TOC -->
 
 <div class="row blog-page">
   <div class="col-12">


### PR DESCRIPTION
Generalize the comment and remove it from the archive, because it's pretty ugly on there.