### PR TITLE
Remove TOC comment hack

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -35,9 +35,8 @@
       </div>
     </div>
   </div>
-
-  <!-- Comment to remove TOC from a page -->
-  {% if content contains '<!-- No TOC -->' or page.show_pagenav==false %}
+  
+  {% if page.show_pagenav==false %}
     {{ content }}
   {% else %}
     <div class="row" style="margin-left:0; margin-right:0;">

--- a/blog/archive.md
+++ b/blog/archive.md
@@ -1,12 +1,10 @@
 ---
 layout: blog
 title: Blog archives
+show_pagenav: false
 ---
 
 <div class="content container clearfix spacer-30">
-
-<!-- Ensures table of contents isn't displayed on this page, don't remove. -->
-<!-- No TOC -->
 
 <div class="row blog-page">
   <div class="col-12 text-surface-medium">

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,12 +1,10 @@
 ---
 layout: blog
 title: Trino blog
+show_pagenav: false
 ---
 
 <div class="content container clearfix spacer-30">
-
-<!-- Ensures table of contents isn't displayed on this page, don't remove. -->
-<!-- No TOC -->
 
 <div class="row blog-page">
   <div class="col-12">


### PR DESCRIPTION
We don't need do the comment hackery if we can just make it a header property, so here's a little bit of cleanup.
Higher-effort follow-up is to have the TOC off by default, then go manually enable it for the blogs that need it.