### PR TITLE
Clarify merge requirements

### DIFF
--- a/development/process.md
+++ b/development/process.md
@@ -82,8 +82,14 @@ keep the amount of rework from the contributor to a minimum.
     3. Go to step 5.
 
 8. Maintainer merges the pull request after final changes are accepted.
+
+    * Approval of one maintainer is required for merge. This includes cases when
+      the author of the PR is a maintainer, and a second maintainer reviews, and
+      approves the PR. In these cases either maintainer can merge the PR.
+    * Approvals and input from other reviewers are helpful for the decision of
+      the maintainers, but not required.
     * In the event that the maintainer team is divided on whether a particular
-      contribution should be merged, final say will defer to the [BDFLs](/development/roles.html)
+      contribution should be merged, the final decision is made by the [BDFLs](/development/roles.html)
       of the project.
 
 </div>

--- a/development/process.md
+++ b/development/process.md
@@ -83,14 +83,26 @@ keep the amount of rework from the contributor to a minimum.
 
 8. Maintainer merges the pull request after final changes are accepted.
 
-    * Approval of one maintainer is required for merge. This includes cases when
-      the author of the PR is a maintainer, and a second maintainer reviews, and
-      approves the PR. In these cases either maintainer can merge the PR.
+    * Approval of a reviewing maintainer is required before a pull request can
+      be merged. If a maintainer authors a pull request, another maintainer must
+      approve it.
     * Approvals and input from other reviewers are helpful for the decision of
       the maintainers, but not required.
     * In the event that the maintainer team is divided on whether a particular
       contribution should be merged, the final decision is made by the [BDFLs](/development/roles.html)
       of the project.
+
+9. Maintainers organize a release to ship the next Trino version with your
+   improvements.
+
+    * All maintainers and the DevRel team collaborate to include your change in
+      the release notes.
+    * Roughly every week, the maintainers initiate a new release build. Exact
+      timing depends on any release blocker issues and availability to run the
+      release build.
+    * After the release all binaries are available and the documentation and the
+      website are updated.
+    * Finally the release is announced.
 
 </div>
 </div>


### PR DESCRIPTION
Also note that I think we should add more info on what happens afterwards. I can do that in a follow up PR or in this one .. 

Basically 

* Maintainers and dev rel team organize release note entry for PR.
* Maintainers initiate release when possible, Aim is to release once a week. 
* The release gets the changes from the PR to users in the forms of updates binaries and documentation.


Wdyt @martint .. should I address the above points in this PR as well? Or a follow up?