### PR TITLE
Add redirect from current file path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,6 +14,10 @@
   to = "/docs/current/"
 
 [[redirects]]
+  from = "/docs/current"
+  to = "/docs/current/"
+
+[[redirects]]
   from = "/docs/*"
   to = "https://trinodb.github.io/docs.trino.io/:splat"
   status = 200


### PR DESCRIPTION
This is an attempt to fix https://github.com/trinodb/trino/issues/17906 

I am assuming that netlify uses the configs in order and that this actually works. To test .. we might have to actually merge.

Wdyt @martint @bitsondatadev @colebow ?