### PR TITLE
Resolve redirect loop

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,10 +14,6 @@
   to = "/docs/current/"
 
 [[redirects]]
-  from = "/docs/current"
-  to = "/docs/current/"
-
-[[redirects]]
   from = "/docs/*"
   to = "https://trinodb.github.io/docs.trino.io/:splat"
   status = 200


### PR DESCRIPTION
The test from https://github.com/trinodb/trino.io/pull/456 failed.. it somehow created a redirect loop in production rather than working like it did locally. Undoing that old PR therefore with this.