### PR TITLE
Add missing Community link to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,6 +23,12 @@
       <!-- Grid column -->
       <div class="col-md-2 mb-3">
         <h6>
+          <a href="/community/">Community</a>
+        </h6>
+      </div>
+      <!-- Grid column -->
+      <div class="col-md-2 mb-3">
+        <h6>
           <a href="/development/">Development</a>
         </h6>
       </div>


### PR DESCRIPTION
Makes the footer a mirror of the nav in the header .. we must have missed adding it when we updated the header.