### PR TITLE
Add Starburst and JioSaavn as highlighted users on home page

### DIFF
--- a/_data/users.yml
+++ b/_data/users.yml
@@ -348,7 +348,7 @@
     - urltext: View the Jampp website
       url: https://jampp.com/
 - name: JioSaavn
-  highlight: false
+  highlight: true
   anchor: jiosaavn
   logo: /assets/images/logos/jiosaavn.png
   logosmall: /assets/images/logos/jiosaavn-small.png
@@ -679,7 +679,7 @@
     - urltext: Shopify's Path to a Faster Trino Query Execution - Infrastructure
       url: https://shopify.engineering/faster-trino-query-execution-infrastructure
 - name: Starburst
-  highlight: false
+  highlight: true
   anchor: starburst
   logo: /assets/images/logos/starburst.png
   logosmall: /assets/images/logos/starburst-small.png

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -989,9 +989,9 @@ table td {
 }
 
 .user-logo-item {
-  max-width: 10%; /* 10 Column */
-  -ms-flex: 0 0 10%;
-  flex: 0 0 10%;
+  max-width: 9%; /* 10 Column */
+  -ms-flex: 0 0 9%;
+  flex: 0 0 9%;
 }
 
 @media (max-width: 769px) {


### PR DESCRIPTION
This updates the display on the home page and the users page to use rows of 11 logos. Therefore on the homepage to be 2 rows of 11 - total of 22. Up from 20. As a result the logos are a bit smaller.