### PR TITLE
Fix links to subprojects

### DIFF
--- a/development/roles.md
+++ b/development/roles.md
@@ -252,12 +252,12 @@ Trino project. They are often associated to a specific aspect of running the
 project or a technology stack and integration for Trino.
 
 Examples for subproject repositories are the
-[trino.io]({{site.github_repo_url}}/grafana-trino) website source or the
-[grafana-trino]({{site.github_repo_url}}/grafana-trino) repository for the Trino
+[trino.io]({{site.github_org_url}}/trino.io) website source or the
+[grafana-trino]({{site.github_org_url}}/grafana-trino) repository for the Trino
 Grafana data source plugin. Other potential subprojects are
-[trino-python-client]({{site.github_repo_url}}/trino-python-client),
-[trino-go-client]({{site.github_repo_url}}/trino-go-client), and
-[charts]({{site.github_repo_url}}/charts).
+[trino-python-client]({{site.github_org_url}}/trino-python-client),
+[trino-go-client]({{site.github_org_url}}/trino-go-client), and
+[charts]({{site.github_org_url}}/charts).
 
 **Expectations and duties:**
 
@@ -269,9 +269,9 @@ technologies.
 
 The following subproject repositories and subproject maintainers are configured:
 
-* [grafana-trino]({{site.github_repo_url}}/grafana-trino)
+* [grafana-trino]({{site.github_org_url}}/grafana-trino)
   * Jan Waś [<i class="fab fa-github"></i> nineinchnick](https://github.com/nineinchnick)
-* [trino.io]({{site.github_repo_url}}/trino.io)
+* [trino.io]({{site.github_org_url}}/trino.io)
   * Brian Olsen [<i class="fab fa-github"></i> bitsondatadev](https://github.com/bitsondatadev)
 
 ## Language Lead


### PR DESCRIPTION
Fix urls in roles page.
The link should be org url, not repo url. 
- github_org_url: "https://github.com/trinodb"
- github_repo_url: "https://github.com/trinodb/trino"
- https://github.com/trinodb/trino.io/blob/master/_config.yml#L28-L29