### PR TITLE
Remove Ruby gems warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,6 @@ group :jekyll_plugins do
 end
 
 gem "webrick", "~> 1.8.1"
+gem "csv"
+gem "base64"
+gem "bigdecimal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,11 @@ GEM
   specs:
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
     colorator (1.1.0)
     concurrent-ruby (1.2.3)
+    csv (3.2.8)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -60,19 +63,19 @@ GEM
     rexml (3.2.6)
     rouge (4.2.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.69.7-aarch64-linux-android)
+    sass-embedded (1.70.0-aarch64-linux-android)
       google-protobuf (~> 3.25)
-    sass-embedded (1.69.7-arm-linux-androideabi)
+    sass-embedded (1.70.0-arm-linux-androideabi)
       google-protobuf (~> 3.25)
-    sass-embedded (1.69.7-arm-linux-gnueabihf)
+    sass-embedded (1.70.0-arm-linux-gnueabihf)
       google-protobuf (~> 3.25)
-    sass-embedded (1.69.7-arm-linux-musleabihf)
+    sass-embedded (1.70.0-arm-linux-musleabihf)
       google-protobuf (~> 3.25)
-    sass-embedded (1.69.7-arm64-darwin)
+    sass-embedded (1.70.0-arm64-darwin)
       google-protobuf (~> 3.25)
-    sass-embedded (1.69.7-x86-linux-android)
+    sass-embedded (1.70.0-x86-linux-android)
       google-protobuf (~> 3.25)
-    sass-embedded (1.69.7-x86_64-linux-android)
+    sass-embedded (1.70.0-x86_64-linux-android)
       google-protobuf (~> 3.25)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -89,6 +92,9 @@ PLATFORMS
   x86_64-linux-android
 
 DEPENDENCIES
+  base64
+  bigdecimal
+  csv
   jekyll (~> 4.3.3)
   jekyll-compose
   jekyll-paginate


### PR DESCRIPTION
Just a clean up to remove build warnings. In future Ruby versions things will break without this update. 