### PR TITLE
Fix links to docs

### DIFF
--- a/_episodes/40.md
+++ b/_episodes/40.md
@@ -5,7 +5,7 @@ date: 2022-09-08
 tags: iceberg apache datalake table format sql schema evolution partition optimize
 youtube_id: "6NyfCV8Me0M"
 wistia_id: "b9nlw7rjpr"
-sections: 
+sections:
    - title: "Releases"
      desc: "394 to 395"
      time: 387
@@ -45,12 +45,12 @@ Looks like Commander Bun Bun is safe on this Iceberg<br/>
 
  * Brian Olsen, Developer Advocate at [Starburst](https://starburst.io)
  ([@bitsondatadev](https://twitter.com/bitsondatadev))
- * [Cole Bowden](https://www.linkedin.com/in/cole-m-bowden), Developer Advocate at 
+ * [Cole Bowden](https://www.linkedin.com/in/cole-m-bowden), Developer Advocate at
  [Starburst](https://starburst.io)
 
 ## Guests
 
- * Ryan Blue, creator of Iceberg and CEO at 
+ * Ryan Blue, creator of Iceberg and CEO at
  [Tabular](https://tabular.io) ([@rdblue](https://github.com/rdblue))
  * Sam Redai, Developer Advocate at [Tabular](https://tabular.io)
  ([@samuelredai](https://twitter.com/samuelredai))
@@ -60,12 +60,12 @@ Looks like Commander Bun Bun is safe on this Iceberg<br/>
 
 Trino Summit 2022 is coming around the corner! This **free** event on November
 10th will take place in-person at the Commonwealth Club in San Francisco, CA or
-can also be attended remotely!  If you want to present, the 
+can also be attended remotely!  If you want to present, the
 [call for speakers](https://sessionize.com/trino-summit-2022/) is open until
-September 15th. 
+September 15th.
 
 [You can register for the conference](https://www.starburst.io/info/trinosummit/)
-at any time. We must limit in-person registrations to 250 
+at any time. We must limit in-person registrations to 250
 attendees, so register soon if you plan on attending in person!
 
 ## Releases 394 to 395
@@ -95,7 +95,7 @@ one. We're not entirely sure how much it'll matter in production use cases, but
 some of the benchmarks suggested it could be massive - one test showed a 75%
 reduction in query duration.
 * Dynamic function resolution in the SPI is going to unlock some very neat
-possibilities down the line. 
+possibilities down the line.
 
 More detailed information is available in the release notes for
 [Trino 394]({{site.url}}/docs/current/release/release-394.html),
@@ -107,10 +107,10 @@ and
 It has been over a year since we had Ryan on the Trino Community Broadcast as
 guest to discuss what Apache Iceberg is and how it can be used in Trino. Since
 then, the adoption of Iceberg in our community has skyrocketed. Iceberg is
-delivering as a much better alternative to the Hive table format. 
+delivering as a much better alternative to the Hive table format.
 
-The initial phase of the Iceberg connector in Trino aimed to provide fast and 
-interoperable read support. A typical usage was Trino alongside other query 
+The initial phase of the Iceberg connector in Trino aimed to provide fast and
+interoperable read support. A typical usage was Trino alongside other query
 engines like Apache Spark which supported many of the data modification language
 (DML) SQL features on Iceberg. One of the biggest requests we got as adoption
 increased was the ability to do everything through Trino. This episode dives
@@ -119,15 +119,15 @@ the Iceberg connector and what has changed in Iceberg as well!
 
 ### What is Apache Iceberg?
 
-[Iceberg](https://iceberg.apache.org/) is a next-generation table format that 
-defines a standard around the metadata used to map data to a SQL query engine. 
+[Iceberg](https://iceberg.apache.org/) is a next-generation table format that
+defines a standard around the metadata used to map data to a SQL query engine.
 It addresses a lot of the maintainability and reliability issues many engineers
 experienced with the way
-[Hive modeled SQL tables]({% post_url 2020-10-20-intro-to-hive-connector %}) 
-over big data files. 
+[Hive modeled SQL tables]({% post_url 2020-10-20-intro-to-hive-connector %})
+over big data files.
 
 One common confusion to point out is that table format is not equivalent to file
-formats like ORC or Parquet. The table format is the layer that maintains 
+formats like ORC or Parquet. The table format is the layer that maintains
 metadata mapping these files to the concept of a table and other common database
 abstractions.
 
@@ -156,27 +156,27 @@ running with Iceberg. All of this is made possible by the
 [Iceberg specification](https://iceberg.apache.org/spec) that all these query
 engines must follow.
 
-Finally, a great video presented by Ryan Blue that dives into Iceberg is, 
+Finally, a great video presented by Ryan Blue that dives into Iceberg is,
 "[Why you shouldn't care about Iceberg](https://www.youtube.com/watch?v=_GW3GYZK66U)."
 
 ### Metadata catalogs
 
 Catalogs, in the context of Iceberg, refer to the central storage of metadata.
-Catalogs are also used to provide the atomic compare-and-swap needed to support 
+Catalogs are also used to provide the atomic compare-and-swap needed to support
 [serializable isolation in Iceberg](https://iceberg.apache.org/docs/latest/reliability).
-We'll refer to them as metadata catalogs to avoid confusion with Trino 
+We'll refer to them as metadata catalogs to avoid confusion with Trino
 [catalogs](https://trino.io/docs/current/sql/show-catalogs.html).
 
-The two existing catalogs supported in Trino's Iceberg connector are the 
+The two existing catalogs supported in Trino's Iceberg connector are the
 [Hive Metastore Service]({{site.url}}/docs/current/connector/iceberg.html#hive-metastore-catalog)
-and the AWS metastore counterpart of the Hive Metastore, Glue. While this 
+and the AWS metastore counterpart of the Hive Metastore, Glue. While this
 provides a nice migration from the Hive model, many are looking to replace these
 rather cumbersome catalogs with something that's lightweight. It turns out that
 the Iceberg connector only uses the Hive Metastore Service to point to top-level
 metadata files in Iceberg while the majority of metadata exist in the metastore
 files in storage. This makes it even more compelling to get rid of the complex
 Hive service in favor of simpler services. Two popular catalogs outside of these
-are the [JDBC catalog](https://iceberg.apache.org/docs/latest/jdbc) and the 
+are the [JDBC catalog](https://iceberg.apache.org/docs/latest/jdbc) and the
 [REST catalog](https://github.com/apache/iceberg/pull/4348).
 
 There are two PRs in progress to support these metadata catalogs in Trino:
@@ -186,20 +186,20 @@ There are two PRs in progress to support these metadata catalogs in Trino:
 
 ### Branching, tagging, and auditing, oh my!
 
-Another feature set that is coming in Iceberg is the ability to use 
+Another feature set that is coming in Iceberg is the ability to use
 [refs to alias your snapshots](https://github.com/apache/iceberg/pull/5364).
 This would enable branching and tagging behavior similar to git and treating
 the snapshot as a commit. This is yet another way that simplifies moving between
 known states of the data in Iceberg.
 
-On a related note, branching and tagging will eventually be used in the 
+On a related note, branching and tagging will eventually be used in the
 [audit integration in Iceberg](https://tabular.io/blog/integrated-audits).
-Auditing allows you to push a soft commit by making a snapshot available, but 
+Auditing allows you to push a soft commit by making a snapshot available, but
 it is not initially published to the primary table. This is achieved using Spark
 and setting the `spark.wap.id` configuration property. This enables interesting
-patterns like 
+patterns like
 [Write-Audit-Publish (WAP) pattern](https://www.dremio.com/subsurface/write-audit-publish-pattern-via-apache-iceberg/),
-where you first write the data, audit it using a data quality tool like 
+where you first write the data, audit it using a data quality tool like
 [Great Expectations](https://greatexpectations.io), and lastly publish the data
 to be visible from the main table. Currently, auditing has to use the
 cherry-pick operation to publish. This becomes more streamlined with branching
@@ -208,10 +208,10 @@ and tagging.
 ### The Puffin file format
 
 The [Puffin file format](https://iceberg.apache.org/puffin-spec) is an
-alternative to [Parquet](https://parquet.apache.org/) and 
-[ORC](https://orc.apache.org/). This format stores information such as indexes 
-and statistics about data managed in an Iceberg table that cannot be stored 
-directly within the Iceberg manifest. A Puffin file contains arbitrary pieces of 
+alternative to [Parquet](https://parquet.apache.org/) and
+[ORC](https://orc.apache.org/). This format stores information such as indexes
+and statistics about data managed in an Iceberg table that cannot be stored
+directly within the Iceberg manifest. A Puffin file contains arbitrary pieces of
 information called “blobs”, along with metadata necessary to interpret them.
 
 This format [was proposed](https://www.mail-archive.com/dev@iceberg.apache.org/msg03593.html)
@@ -222,7 +222,7 @@ query plans in Trino at the file level.
 
 ### pyIceberg
 
-The [pyIceberg library](https://github.com/apache/iceberg/tree/master/python) 
+The [pyIceberg library](https://github.com/apache/iceberg/tree/master/python)
 is an exciting development that enables users to read their data directly from
 Iceberg into their own Python code easily.
 
@@ -231,15 +231,15 @@ Iceberg into their own Python code easily.
 * [`MERGE`]({{site.url}}/docs/current/sql/merge) ([PR](https://github.com/trinodb/trino/pull/7933))
 * [`UPDATE`]({{site.url}}/docs/current/sql/update) ([PR](https://github.com/trinodb/trino/pull/12026))
 * [`DELETE`]({{site.url}}/docs/current/sql/delete) ([PR](https://github.com/trinodb/trino/pull/11886))
-* Time travel ([PR](https://github.com/trinodb/trino/pull/10258)) was initially 
-released in 
-[version 385]({{site.url}}docs/current/release/release-385.html#iceberg-connector),
+* Time travel ([PR](https://github.com/trinodb/trino/pull/10258)) was initially
+released in
+[version 385]({{site.url}}/docs/current/release/release-385.html#iceberg-connector),
 the `@` syntax for snapshots/time travel
-[was deprecated](https://github.com/trinodb/trino/pull/10768) in 
-[version 387]({{site.url}}docs/current/release/release-387.html#iceberg-connector),
-and there were two bug fixes for this feature in versions 
-[386]({{site.url}}docs/current/release/release-386.html#iceberg-connector) and
-[388]({{site.url}}docs/current/release/release-388.html#iceberg-connector).
+[was deprecated](https://github.com/trinodb/trino/pull/10768) in
+[version 387]({{site.url}}/docs/current/release/release-387.html#iceberg-connector),
+and there were two bug fixes for this feature in versions
+[386]({{site.url}}/docs/current/release/release-386.html#iceberg-connector) and
+[388]({{site.url}}/docs/current/release/release-388.html#iceberg-connector).
 * [Partition migration]({{site.url}}/docs/current/connector/iceberg.html#alter-table-set-properties)
 ([PR](https://github.com/trinodb/trino/pull/12259))
 While Trino was able to read tables with these migrations applied by other query
@@ -247,7 +247,7 @@ engines, this feature allows Trino to write these changes.
 * The following three features are table maintenance commands.
     * [`optimize`]({{site.url}}/docs/current/connector/iceberg.html#optimize)
 ([PR](https://github.com/trinodb/trino/pull/10497)) which is the equivalent to
-the Spark SQL 
+the Spark SQL
 [rewrite_data_files](https://iceberg.apache.org/docs/latest/spark-procedures/#rewrite_data_files).
     * [`expire_snapshots`]({{site.url}}/docs/current/connector/iceberg.html#expire-snapshots)
 ([PR](https://github.com/trinodb/trino/pull/10810)) and uses the equivalent name
@@ -258,16 +258,16 @@ in Spark.
 * Iceberg v2 support ([PR1](https://github.com/trinodb/trino/pull/11880), [PR2](https://github.com/trinodb/trino/pull/12351), [PR3](https://github.com/trinodb/trino/pull/12749), [PR4](https://github.com/trinodb/trino/pull/11642), [PR5](https://github.com/trinodb/trino/pull/9881), and many more...)
 
 
-Almost every release has some sort of Iceberg improvement around 
+Almost every release has some sort of Iceberg improvement around
 [planning](https://github.com/trinodb/trino/pull/13636) or
-[pushdown](https://github.com/trinodb/trino/pull/13395). If you want all the 
+[pushdown](https://github.com/trinodb/trino/pull/13395). If you want all the
 latest features and performance improvements described here, it's important to
 keep up with the latest Trino version.
 
 ## PR 13111: Scale table writers per task based on throughput
 
-This [PR of the episode](https://github.com/trinodb/trino/pull/13111) was 
-contributed by Gaurav Sehgal ([@gaurav8297](https://github.com/gaurav8297)) to 
+This [PR of the episode](https://github.com/trinodb/trino/pull/13111) was
+contributed by Gaurav Sehgal ([@gaurav8297](https://github.com/gaurav8297)) to
 enable Trino to automatically scale writers. This PR aims to the number of task
 writers per worker.
 
@@ -282,7 +282,7 @@ For this demo of the episode, we use the same schema as the demo we ran in
 [episode 15]({{site.url}}/episodes/15.html), and revise the syntax to
 include new features.
 
-Let's start up a local Trino coordinator and Hive metastore. Clone the 
+Let's start up a local Trino coordinator and Hive metastore. Clone the
 repository and navigate to the `iceberg/trino-iceberg-minio` directory. Then
 start up the containers using Docker Compose.
 
@@ -292,7 +292,7 @@ cd iceberg/trino-iceberg-minio
 docker-compose up -d
 ```
 
-Now open up your favorite Trino client and connect it to 
+Now open up your favorite Trino client and connect it to
 `localhost:8080` to run the following commands:
 
 ```
@@ -303,7 +303,7 @@ CREATE SCHEMA iceberg.logging
 WITH (location = 's3a://logging/');
 
 /**
- * Create table 
+ * Create table
  */
 CREATE TABLE iceberg.logging.logs (
    level varchar NOT NULL,
@@ -321,17 +321,17 @@ WITH (
  * Inserting two records. Notice event_time is on the same day but different hours.
  */
 
-INSERT INTO iceberg.logging.logs VALUES 
+INSERT INTO iceberg.logging.logs VALUES
 (
-  'ERROR', 
-  timestamp '2021-04-01 12:23:53.383345' AT TIME ZONE 'America/Los_Angeles', 
+  'ERROR',
+  timestamp '2021-04-01 12:23:53.383345' AT TIME ZONE 'America/Los_Angeles',
   '1 message',
   ARRAY ['Exception in thread "main" java.lang.NullPointerException']
 ),
 (
-  'ERROR', 
-  timestamp '2021-04-01 13:36:23' AT TIME ZONE 'America/Los_Angeles', 
-  '2 message', 
+  'ERROR',
+  timestamp '2021-04-01 13:36:23' AT TIME ZONE 'America/Los_Angeles',
+  '2 message',
   ARRAY ['Exception in thread "main" java.lang.NullPointerException']
 );
 
@@ -345,29 +345,29 @@ SELECT * FROM iceberg.logging."logs$partitions";
 /**
  * Update the partitioning from daily to hourly 🎉
  */
-ALTER TABLE iceberg.logging.logs 
+ALTER TABLE iceberg.logging.logs
 SET PROPERTIES partitioning = ARRAY['hour(event_time)'];
 
 /**
  * Inserting three records. Notice event_time is on the same day but different hours.
  */
-INSERT INTO iceberg.logging.logs VALUES 
+INSERT INTO iceberg.logging.logs VALUES
 (
-  'ERROR', 
-  timestamp '2021-04-01 15:55:23' AT TIME ZONE 'America/Los_Angeles', 
-  '3 message', 
+  'ERROR',
+  timestamp '2021-04-01 15:55:23' AT TIME ZONE 'America/Los_Angeles',
+  '3 message',
   ARRAY ['Exception in thread "main" java.lang.NullPointerException']
-), 
+),
 (
-  'WARN', 
-  timestamp '2021-04-01 15:55:23' AT TIME ZONE 'America/Los_Angeles', 
-  '4 message', 
+  'WARN',
+  timestamp '2021-04-01 15:55:23' AT TIME ZONE 'America/Los_Angeles',
+  '4 message',
   ARRAY ['bad things could be happening']
-), 
+),
 (
-  'WARN', 
-  timestamp '2021-04-01 16:55:23' AT TIME ZONE 'America/Los_Angeles', 
-  '5 message', 
+  'WARN',
+  timestamp '2021-04-01 16:55:23' AT TIME ZONE 'America/Los_Angeles',
+  '5 message',
   ARRAY ['bad things could be happening']
 );
 
@@ -381,7 +381,7 @@ SELECT * FROM iceberg.logging."logs$partitions";
  * 3) One at the hour granularity for hour 16 containing the last new record.
  */
 
-SELECT * FROM iceberg.logging.logs 
+SELECT * FROM iceberg.logging.logs
 WHERE event_time < timestamp '2021-04-01 16:55:23' AT TIME ZONE 'America/Los_Angeles';
 
 /**
@@ -389,7 +389,7 @@ WHERE event_time < timestamp '2021-04-01 16:55:23' AT TIME ZONE 'America/Los_Ang
  * being touched. Now let's check the snapshots.
  */
 
- 
+
 SELECT * FROM iceberg.logging.logs;
 
 SELECT * FROM iceberg.logging."logs$snapshots";
@@ -428,20 +428,20 @@ WITH (
    format = 'ORC'
 );
 
-INSERT INTO iceberg.logging.src VALUES 
+INSERT INTO iceberg.logging.src VALUES
  (
    'ERROR',
-   '3 message', 
+   '3 message',
    ARRAY ['This one will not show up because it is an ERROR']
- ), 
- (
-   'WARN', 
-   '4 message', 
-   ARRAY ['This should show up']
- ), 
+ ),
  (
    'WARN',
-   '5 message', 
+   '4 message',
+   ARRAY ['This should show up']
+ ),
+ (
+   'WARN',
+   '5 message',
    ARRAY ['This should show up as well']
  );
 
@@ -452,7 +452,7 @@ WHEN MATCHED AND s.level = 'ERROR'
         THEN DELETE
 WHEN MATCHED
     THEN UPDATE
-        SET message = s.message || '-updated', 
+        SET message = s.message || '-updated',
             call_stack = s.call_stack || t.call_stack;
 
 DROP TABLE iceberg.logging.logs;
@@ -460,7 +460,7 @@ DROP TABLE iceberg.logging.logs;
 DROP SCHEMA iceberg.logging;
 ```
 
-This is just the tip of the iceberg that shows the powerful `MERGE` statement 
+This is just the tip of the iceberg that shows the powerful `MERGE` statement
 and the other features we have added to Iceberg!
 
 ## Events, news, and various links

--- a/_posts/2023-11-03-java-21.md
+++ b/_posts/2023-11-03-java-21.md
@@ -64,5 +64,5 @@ channel](https://trinodb.slack.com/archives/CP1MUNEUX). Or leave comments in our
 We want to hear from you. Any input and feedback is welcome.
 
 > **Update from 11 Jan 2024:**
-> The release of [Trino 436]({{site.url}}docs/current/release/release-436.html)
+> The release of [Trino 436]({{site.url}}/docs/current/release/release-436.html)
 > includes the switch to Java 21 as a requirement for running Trino.

--- a/_posts/2024-02-06-opa-arrived.md
+++ b/_posts/2024-02-06-opa-arrived.md
@@ -68,7 +68,7 @@ worked successfully with Dain on the code review and necessary changes, and
 helped Manfred with the documentation.
 
 Finally, with the release of Trino 438, the [Open Policy Agent access
-control]({{site.url}}docs/current/security/opa-access-control.html) is available
+control]({{site.url}}/docs/current/security/opa-access-control.html) is available
 to all Trino users.
 
 The community is already taking notice with follow up pull requests for further

--- a/_posts/2024-03-13-java-22.md
+++ b/_posts/2024-03-13-java-22.md
@@ -9,7 +9,7 @@ show_pagenav: true
 
 It was not that long ago that we [first announced support for Java 21]({%
 post_url 2023-11-03-java-21 %}), and subsequently made it a build and runtime
-requirement with [Trino 436]({{site.url}}docs/current/release/release-436.html).
+requirement with [Trino 436]({{site.url}}/docs/current/release/release-436.html).
 
 Since then, the codebase received some significant improvements in readability,
 and we have also seen better performance. However, innovation in Trino and Java
@@ -110,5 +110,5 @@ Slack]({{site.url}}/slack.html).
 Join us in this exciting next step for Trino.
 
 > **Update from 8 May 2024:**
-> The release of [Trino 447]({{site.url}}docs/current/release/release-447.html)
+> The release of [Trino 447]({{site.url}}/docs/current/release/release-447.html)
 > includes the switch to Java 22 as a requirement for running Trino.


### PR DESCRIPTION
Just adding the missing "/" in a bunch of places after finding one busted link on the site and doing a search for same pattern.

Also removes a bunch of noise from trailing spaces.