### PR TITLE
Remove Google podcast icon

### DIFF
--- a/broadcast/index.md
+++ b/broadcast/index.md
@@ -63,9 +63,6 @@ join the [Trino slack]({{site.url}}/slack) and contact us there.
 <a href="https://podcasts.apple.com/us/podcast/trino-community-broadcast/id1533484786" target="_blank">
   <i class="fab fa-apple watch-listen-icon" title="Apple"></i>
 </a>
-<a href="https://podcasts.google.com/feed/aHR0cHM6Ly9mYXN0Lndpc3RpYS5jb20vY2hhbm5lbHMvN2Z1dzA0czd2Yy9yc3M" target="_blank">
-  <i class="fab fa-google watch-listen-icon" title="Google"></i>
-</a>
 - <a href="{{ '/broadcast/feed.xml' | relative_url }}">Subscribe via RSS</a>
 
 </div>


### PR DESCRIPTION
- Google podcast was killed by Google