### PR TITLE
Remove EA's talk about AWS Glue

### DIFF
--- a/_data/users.yml
+++ b/_data/users.yml
@@ -299,8 +299,6 @@
   links:
     - urltext: View the Electronic Arts website
       url: https://www.ea.com/
-    - urltext: How EA migrated 150+ million partitions from HMS to AWS Glue at Trino Summit 2023
-      url: https://www.youtube.com/watch?v=EF56Ia_hwlo
     - urltext: Electronic Arts interview at Trino meetup August 2022
       url: https://www.youtube.com/watch?v=KY5DhWSqjGg
 - name: Flippa

--- a/_posts/2023-11-22-trino-summit-2023-nears-lineup.md
+++ b/_posts/2023-11-22-trino-summit-2023-nears-lineup.md
@@ -87,7 +87,7 @@ implementing a post-commit integration test suite that ensures nothing has
 broken, and creating an automated test framework that can validate the
 performance of each new Trino release before it deploys to users.
 
-## EA: Migrating 120 million HMS metadata records to AWS Glue without customer impact
+## EA: Migrating 120 million HMS metadata records without customer impact
 
 Migrating production databases is a scary task no matter who you are. It's
 scarier when you're talking about 600+ databases, 35,000+ tables, and over 120

--- a/_posts/2023-12-18-trino-summit-recap.md
+++ b/_posts/2023-12-18-trino-summit-recap.md
@@ -40,9 +40,6 @@ session with the presentation and further details.
   presented by Martin Traverso from
   [Starburst](https://www.starburst.io){:target="_blank"}.
   [(Slides)]({{site.url}}/assets/blog/trino-summit-2023/mountains-trino-climbed.pdf)
-* [How EA migrated 150+ million partitions from HMS to AWS Glue](https://www.youtube.com/watch?v=EF56Ia_hwlo){:target="_blank"}
-  presented by Yuyang Luo from
-  [EA](https://www.ea.com){:target="_blank"}.
 * [Trino workload management](https://www.youtube.com/watch?v=qZejzyxT2fo){:target="_blank"}
   presented by Jinyang Li and Tingting Ma from
   [Airbnb](https://www.airbnb.ccom){:target="_blank"}.


### PR DESCRIPTION
Tony Ma from EA requested that we take this down due to internal policies changing to not talking about AWS Glue, so video is privated and let's remove references to it.