### PR TITLE
Update links to trino getting started repo

### DIFF
--- a/_episodes/13.md
+++ b/_episodes/13.md
@@ -242,7 +242,7 @@ broker. Clone this repository and navigate to the `pinot/trino-pinot` directory.
 ```
 git clone git@github.com:bitsondatadev/trino-getting-started.git
 
-cd pinot/trino-pinot
+cd community_tutorials/pinot/trino-pinot
 
 docker-compose up -d
 ```

--- a/_episodes/16.md
+++ b/_episodes/16.md
@@ -139,7 +139,7 @@ directory.
 ```
 git clone git@github.com:bitsondatadev/trino-getting-started.git
 
-cd druid/trino-druid
+cd community_tutorials/druid/trino-druid
 
 docker-compose up -d
 ```

--- a/_episodes/26.md
+++ b/_episodes/26.md
@@ -172,14 +172,14 @@ demo was moved to its own separate video.
 </div>
 
 The steps in this demo are adapted from the [Amundsen installation page](https://www.amundsen.io/amundsen/installation/).
-Clone this repository and navigate to the `trino-getting-started/amundsen` 
+Clone this repository and navigate to the `trino-getting-started/community_tutorials/amundsen` 
 directory. For this demo you need at least 3GB of memory allocated to your 
 Docker application. 
 
 ```
 git clone git@github.com:bitsondatadev/trino-getting-started.git
 
-cd amundsen
+cd community_tutorials/amundsen
 
 docker-compose up -d
 ```
@@ -220,11 +220,11 @@ WITH (
 AS SELECT * FROM tpch.tiny.orders;
 ```
 
-Navigate back to the `trino-getting-started/amundsen` directory in the same 
+Navigate back to the `trino-getting-started/community_tutorials/amundsen` directory in the same 
 Python virtual environment you just opened. 
 
 ```
-cd trino-getting-started/amundsen
+cd trino-getting-started/community_tutorials/amundsen
 python3 assets/scripts/sample_trino_data_loader.py
 ```
 

--- a/_episodes/27.md
+++ b/_episodes/27.md
@@ -110,12 +110,12 @@ of memory allocated to Docker.
 Let's start up the LakeFS instance and the required PostgreSQL instance along 
 with the typical Trino containers used with the Hive connector. 
 Clone the `trino-getting-started` repository and navigate to the 
-`lakefs/trino-lakefs-minio/` directory. 
+`community_tutorials/lakefs/trino-lakefs-minio/` directory. 
 
 ```
 git clone git@github.com:bitsondatadev/trino-getting-started.git
 
-cd lakefs/trino-lakefs-minio/
+cd community_tutorials/lakefs/trino-lakefs-minio/
 
 docker-compose up -d
 ```

--- a/_episodes/34.md
+++ b/_episodes/34.md
@@ -171,7 +171,7 @@ course Trino as the query engine.
 
 If you want to follow along, all resources used for the demo are [available on
 our getting started
-repository](https://github.com/bitsondatadev/trino-getting-started/tree/main/delta-lake).
+repository](https://github.com/bitsondatadev/trino-getting-started/tree/main/community_tutorials/delta-lake).
 
 
 Here is the sample catalog `delta.properties`:

--- a/_episodes/41.md
+++ b/_episodes/41.md
@@ -248,7 +248,7 @@ start up the containers using Docker Compose.
 
 ```
 git clone git@github.com:bitsondatadev/trino-getting-started.git
-cd hudi/trino-hudi-minio
+cd community_tutorials/hudi/trino-hudi-minio
 docker-compose up -d
 ```
 

--- a/_episodes/43.md
+++ b/_episodes/43.md
@@ -185,7 +185,7 @@ to the location property on the table from the Trino perspective.
 {% youtube yaxPEWRpEzc %}
 
 To follow this demo, copy the code located in the 
-[trino-getting-started repo](https://github.com/bitsondatadev/trino-getting-started/tree/main/iceberg/trino-alluxio-iceberg-minio).
+[trino-getting-started repo](https://github.com/bitsondatadev/trino-getting-started/tree/main/community_tutorials/alluxio/trino-alluxio-iceberg-minio).
 
 Check out the in-person and virtual
 [Trino Meetup groups](https://www.meetup.com/pro/trino-community/).

--- a/_episodes/45.md
+++ b/_episodes/45.md
@@ -192,7 +192,7 @@ For this episodes' demo, we look at creating a workflow consisting of a Trino
 query execution managed by a workflow in DolphinScheduler.
 
 Run the demo by following 
-[the steps listed](https://github.com/bitsondatadev/trino-getting-started/tree/main/dolphinscheduler).
+[the steps listed](https://github.com/bitsondatadev/trino-getting-started/tree/main/community_tutorials/dolphinscheduler).
 
 ## PR of the episode: Improve performance of Parquet files
 


### PR DESCRIPTION
Update links to adhere to [changes being made in the Trino Getting Started Repository](https://github.com/bitsondatadev/trino-getting-started/issues/53).