### PR TITLE
Add redirect for client page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -38,3 +38,7 @@
 [[redirects]]
   from = "/ecosystem/client"
   to = "/ecosystem/index.html"
+  
+[[redirects]]
+  from = "/ecosystem/client.html"
+  to = "/ecosystem/index.html"


### PR DESCRIPTION
@jhlodin found that links with .html are not redirected and reported this as issue. 