### PR TITLE
Remove Brian Olsen as TCB co-host

### DIFF
--- a/broadcast/index.md
+++ b/broadcast/index.md
@@ -44,7 +44,6 @@ join the [Trino slack]({{site.url}}/slack) and contact us there.
 ## Hosts
 
 - [Manfred Moser](https://www.linkedin.com/in/manfredmoser), main organizer and host
-- Brian Olsen [bitsondatadev](https://github.com/bitsondatadev), co-host
 - [Cole Bowden](https://www.linkedin.com/in/cole-m-bowden), co-host
 
 ## Watch


### PR DESCRIPTION
Brian has been inactive on the TCB for over a year.