### PR TITLE
Revert "Upgrade Jekyll, bundler and more"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 #
 #     bundle exec jekyll serve
 
-gem "jekyll", "~> 4.4.1"
+gem "jekyll", "~> 4.3.3"
 
 group :jekyll_plugins do
   gem "jekyll-sitemap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,71 +3,59 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    base64 (0.3.0)
-    bigdecimal (3.2.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
-    csv (3.3.5)
+    csv (3.3.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.2)
-    ffi (1.17.2-aarch64-linux-gnu)
-    ffi (1.17.2-aarch64-linux-musl)
-    ffi (1.17.2-arm-linux-gnu)
-    ffi (1.17.2-arm-linux-musl)
-    ffi (1.17.2-arm64-darwin)
-    ffi (1.17.2-x86-linux-gnu)
-    ffi (1.17.2-x86-linux-musl)
-    ffi (1.17.2-x86_64-darwin)
-    ffi (1.17.2-x86_64-linux-gnu)
-    ffi (1.17.2-x86_64-linux-musl)
+    ffi (1.17.1)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86-linux-gnu)
+    ffi (1.17.1-x86-linux-musl)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    google-protobuf (4.31.1)
+    google-protobuf (4.29.3)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-aarch64-linux-gnu)
+    google-protobuf (4.29.3-aarch64-linux)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-aarch64-linux-musl)
+    google-protobuf (4.29.3-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-arm64-darwin)
+    google-protobuf (4.29.3-x86-linux)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x86-linux-gnu)
+    google-protobuf (4.29.3-x86_64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x86-linux-musl)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.31.1-x86_64-darwin)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.31.1-x86_64-linux-gnu)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.31.1-x86_64-linux-musl)
+    google-protobuf (4.29.3-x86_64-linux)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (4.4.1)
+    jekyll (4.3.4)
       addressable (~> 2.4)
-      base64 (~> 0.2)
       colorator (~> 1.0)
-      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
-      json (~> 2.6)
       kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.3, >= 0.3.6)
+      mercenary (>= 0.3.6, < 0.5)
       pathutil (~> 0.9)
       rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
@@ -76,15 +64,14 @@ GEM
     jekyll-compose (0.12.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
-    jekyll-sass-converter (3.1.0)
-      sass-embedded (~> 1.75)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.12.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -96,54 +83,60 @@ GEM
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.2)
-    rake (13.3.0)
+    public_suffix (6.0.1)
+    rake (13.2.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.1)
-    rouge (4.5.2)
+    rexml (3.4.0)
+    rouge (4.5.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.89.1)
-      google-protobuf (~> 4.31)
+    sass-embedded (1.83.4)
+      google-protobuf (~> 4.29)
       rake (>= 13)
-    sass-embedded (1.89.1-aarch64-linux-android)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-aarch64-linux-gnu)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-aarch64-linux-musl)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-arm-linux-androideabi)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-arm-linux-gnueabihf)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-arm-linux-musleabihf)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-arm64-darwin)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-riscv64-linux-android)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-riscv64-linux-gnu)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-riscv64-linux-musl)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-x86_64-darwin)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-x86_64-linux-android)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-x86_64-linux-gnu)
-      google-protobuf (~> 4.31)
-    sass-embedded (1.89.1-x86_64-linux-musl)
-      google-protobuf (~> 4.31)
+    sass-embedded (1.83.4-aarch64-linux-android)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-aarch64-linux-gnu)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-aarch64-linux-musl)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-aarch64-mingw-ucrt)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-arm-linux-androideabi)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-arm-linux-gnueabihf)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-arm-linux-musleabihf)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-arm64-darwin)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-riscv64-linux-android)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-riscv64-linux-gnu)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-riscv64-linux-musl)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-x86_64-cygwin)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-x86_64-darwin)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-x86_64-linux-android)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-x86_64-linux-gnu)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-x86_64-linux-musl)
+      google-protobuf (~> 4.29)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
     webrick (1.8.2)
 
 PLATFORMS
+  aarch64-linux
   aarch64-linux-android
   aarch64-linux-gnu
   aarch64-linux-musl
+  aarch64-mingw-ucrt
   arm-linux-androideabi
   arm-linux-gnu
   arm-linux-gnueabihf
@@ -154,9 +147,15 @@ PLATFORMS
   riscv64-linux-gnu
   riscv64-linux-musl
   ruby
+  x86-cygwin
+  x86-linux
+  x86-linux-android
   x86-linux-gnu
   x86-linux-musl
+  x86-mingw-ucrt
+  x86_64-cygwin
   x86_64-darwin
+  x86_64-linux
   x86_64-linux-android
   x86_64-linux-gnu
   x86_64-linux-musl
@@ -165,7 +164,7 @@ DEPENDENCIES
   base64
   bigdecimal
   csv
-  jekyll (~> 4.4.1)
+  jekyll (~> 4.3.3)
   jekyll-compose
   jekyll-paginate
   jekyll-seo-tag
@@ -173,4 +172,4 @@ DEPENDENCIES
   webrick (~> 1.8.2)
 
 BUNDLED WITH
-   2.6.9
+   2.5.14

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install bundler using the same version as specified at the end of the
 `Gemfile.lock` file in the project root:
 
 ```bash
-gem install bundler -v '=2.6.9'
+gem install bundler -v '=2.5.14'
 ```
 
 Install gems for site:
@@ -53,19 +53,7 @@ brew install netlify-cli
 
 ### Run server
 
-Run the server with script:
-
-```bash
-./jekyllRun.sh
-```
-
-Also supports for flags to passed to Jekyll:
-
-```bash
-./jekyllRun.sh --future
-```
-
-Alternatively, run the server using Netlify Dev:
+Run server using Netlify Dev:
 
 ```bash
 netlify dev


### PR DESCRIPTION
This reverts commit fa3068020fa460d3587116095b32c0e072a6343f.


Trying to troubleshoot was is happening.. it looks like netlify disappeared on master and in general so I am trying to see if this commit caused it. Currently flying blind since things work locally but there is no netlify log or so.