### PR TITLE
Add Ruby 4 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 #
 #     bundle exec jekyll serve
 
-gem "jekyll", "~> 4.3.3"
+gem "jekyll", "~> 4.4.1"
 
 group :jekyll_plugins do
   gem "jekyll-sitemap"
@@ -18,3 +18,4 @@ gem "webrick", "~> 1.8.2"
 gem "csv"
 gem "base64"
 gem "bigdecimal"
+gem "logger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,17 +54,20 @@ GEM
     http_parser.rb (0.8.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.4)
+    jekyll (4.4.1)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
+      json (~> 2.6)
       kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
       rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
@@ -81,6 +84,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
+    json (2.21.1)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -89,6 +93,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -161,11 +166,12 @@ DEPENDENCIES
   base64
   bigdecimal
   csv
-  jekyll (~> 4.3.3)
+  jekyll (~> 4.4.1)
   jekyll-compose
   jekyll-paginate
   jekyll-seo-tag
   jekyll-sitemap
+  logger
   webrick (~> 1.8.2)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is hosted on [Netlify](https://www.netlify.com/).
 
 ## Build and run locally
 
-In general, you need Ruby, gems, Bundler, Jekyll,
+In general, you need Ruby 4.x, gems, Bundler, Jekyll,
 and [Netlify Dev](https://www.netlify.com/products/dev/).
 
 Detailed steps for macOS follow below.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
-  command = "jekyll build"
+  command = "bundle exec jekyll build"
   publish = "_site"
-  environment = { RUBY_VERSION = "3.3.3" }
+  environment = { RUBY_VERSION = "4.0.6" }
 
 [context.production.environment]
   JEKYLL_ENV = "production"


### PR DESCRIPTION
Upgrade the Trino website build to Ruby 4.0.6.

- Update Jekyll to 4.4.1 and add the `logger` dependency required by Ruby 4.
- Run the Netlify build through Bundler so it uses the locked dependencies.
- Document the Ruby 4.x local development requirement.
