### PR TITLE
Update Ruby gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :jekyll_plugins do
   gem "jekyll-paginate"
 end
 
-gem "webrick", "~> 1.8.2"
+gem "webrick", "~> 1.9.2"
 gem "csv"
 gem "base64"
 gem "bigdecimal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
     bigdecimal (4.1.2)
     colorator (1.1.0)
     concurrent-ruby (1.3.8)
-    csv (3.3.5)
+    csv (3.3.6)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -24,31 +24,31 @@ GEM
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    google-protobuf (4.35.1)
+    google-protobuf (4.36.1)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-aarch64-linux-gnu)
+    google-protobuf (4.36.1-aarch64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-aarch64-linux-musl)
+    google-protobuf (4.36.1-aarch64-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-arm64-darwin)
+    google-protobuf (4.36.1-arm64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86-linux-gnu)
+    google-protobuf (4.36.1-x86-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86-linux-musl)
+    google-protobuf (4.36.1-x86-linux-musl)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-darwin)
+    google-protobuf (4.36.1-x86_64-darwin)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-linux-gnu)
+    google-protobuf (4.36.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    google-protobuf (4.35.1-x86_64-linux-musl)
+    google-protobuf (4.36.1-x86_64-linux-musl)
       bigdecimal
       rake (~> 13.3)
     http_parser.rb (0.8.1)
@@ -84,7 +84,7 @@ GEM
       jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    json (2.21.1)
+    json (2.21.2)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
@@ -106,41 +106,41 @@ GEM
     rexml (3.4.4)
     rouge (4.7.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.101.6)
+    sass-embedded (1.104.0)
       google-protobuf (~> 4.31)
       rake (>= 13)
-    sass-embedded (1.101.6-aarch64-linux-android)
+    sass-embedded (1.104.0-aarch64-linux-android)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-aarch64-linux-gnu)
+    sass-embedded (1.104.0-aarch64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-aarch64-linux-musl)
+    sass-embedded (1.104.0-aarch64-linux-musl)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-arm-linux-androideabi)
+    sass-embedded (1.104.0-arm-linux-androideabi)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-arm-linux-gnueabihf)
+    sass-embedded (1.104.0-arm-linux-gnueabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-arm-linux-musleabihf)
+    sass-embedded (1.104.0-arm-linux-musleabihf)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-arm64-darwin)
+    sass-embedded (1.104.0-arm64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-riscv64-linux-android)
+    sass-embedded (1.104.0-riscv64-linux-android)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-riscv64-linux-gnu)
+    sass-embedded (1.104.0-riscv64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-riscv64-linux-musl)
+    sass-embedded (1.104.0-riscv64-linux-musl)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-x86_64-darwin)
+    sass-embedded (1.104.0-x86_64-darwin)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-x86_64-linux-android)
+    sass-embedded (1.104.0-x86_64-linux-android)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-x86_64-linux-gnu)
+    sass-embedded (1.104.0-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
-    sass-embedded (1.101.6-x86_64-linux-musl)
+    sass-embedded (1.104.0-x86_64-linux-musl)
       google-protobuf (~> 4.31)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    webrick (1.8.2)
+    webrick (1.9.2)
 
 PLATFORMS
   aarch64-linux-android
@@ -173,16 +173,16 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   logger
-  webrick (~> 1.8.2)
+  webrick (~> 1.9.2)
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
-  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
+  bundler (4.0.20) sha256=7978a8ac648767f5e635bc522445b79e80a52b907a39a36c2d8085ed6bc762ae
   colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1
-  csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
+  csv (3.3.6) sha256=aba61e7e507a66f03d45cb1f3c4b6359861c3504038b422962875dce099e4456
   em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
   eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
   ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
@@ -197,15 +197,15 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
-  google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
-  google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
-  google-protobuf (4.35.1-aarch64-linux-musl) sha256=d5c65cef6bd6498a9e5ed5f88cf6cf7e341c10b0a005e32137d5d1a2b6e8c18a
-  google-protobuf (4.35.1-arm64-darwin) sha256=d9c957df04fa89c749fa9a72a7b383eb4296efc9b2303dc6fd6fbe39c698ad6b
-  google-protobuf (4.35.1-x86-linux-gnu) sha256=cc7492566b27ad8b5dfa3a7b6f9b11e905050cc53c2fa8ff22de375a9e7a70fb
-  google-protobuf (4.35.1-x86-linux-musl) sha256=ab403790b59e4dc588ffbed1eaacf05d4ca2f0d12ac9c13d6c64e69380d8c99e
-  google-protobuf (4.35.1-x86_64-darwin) sha256=66b62b4df00931018a692806df66393efa960d6d2b7da69735187249f950d3ee
-  google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
-  google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
+  google-protobuf (4.36.1) sha256=893ac9d66b36b6ea50da5418f856bc7c2d2072099a578aeefc2d7757dcab6a77
+  google-protobuf (4.36.1-aarch64-linux-gnu) sha256=3883fa1b0e99221f68f4a8511bc4fb1888897dcb6cc8bf2805c92c16fc99b499
+  google-protobuf (4.36.1-aarch64-linux-musl) sha256=6da393554ecc96168ae6ddf663392bf8ce4e4fce7c18fda348882ce2e97d6a87
+  google-protobuf (4.36.1-arm64-darwin) sha256=4d82184f4582dfa123f9793cd7a73beca9b0d3f0d3717948c4120b6cc0d50f2d
+  google-protobuf (4.36.1-x86-linux-gnu) sha256=4ea208a8d1a2369728da03e256fc7b454c6781bac486cbfa57d0ed7a0e6352f0
+  google-protobuf (4.36.1-x86-linux-musl) sha256=ec302210ea53f136027f556904b0d13eaf7b4d17fd88b15ddd64b2f321c85dfd
+  google-protobuf (4.36.1-x86_64-darwin) sha256=e92bf3c90c0a9c410cbe430cf366190b1b9b5b2b784f6195a43a178c2ef7e338
+  google-protobuf (4.36.1-x86_64-linux-gnu) sha256=e735a3f3d6596b1010013c2030778bc030770e659106fe7e4ae0f07631b551cb
+  google-protobuf (4.36.1-x86_64-linux-musl) sha256=ae2712b7960e8b1f96d52fef8c2c0dc1cd230f2be13e48492dad0aa2a6a7cf03
   http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   jekyll (4.4.1) sha256=4c1144d857a5b2b80d45b8cf5138289579a9f8136aadfa6dd684b31fe2bc18c1
@@ -215,7 +215,7 @@ CHECKSUMS
   jekyll-seo-tag (2.9.0) sha256=0260015a8e1df9bf195cdfb0c675b7b2883fd8cbf12556e1c1cbe36a831c6852
   jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
@@ -230,24 +230,24 @@ CHECKSUMS
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
   safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
-  sass-embedded (1.101.6) sha256=7c1ccfb07d2e8b87e2b4668b06399a8899cac1cd3dcd3ac6a10eab47e8586fc4
-  sass-embedded (1.101.6-aarch64-linux-android) sha256=4cd8a6e5f9bff8aeb3e2eb5300c53df1e127a2077ddc09bd1d1ca04ea069cf13
-  sass-embedded (1.101.6-aarch64-linux-gnu) sha256=6835585750627925a35070485d7fa055dcc39fe1713a596af15589d62ce4f9d3
-  sass-embedded (1.101.6-aarch64-linux-musl) sha256=d4b91da97d247d9298dfc78efbe9bc9859078efe12c9e4a9be96a178dcc48fb3
-  sass-embedded (1.101.6-arm-linux-androideabi) sha256=617b81befc339c9d8b39502f2a6e7f7c0486c27149b642bc6c58c9ab6e2dda5c
-  sass-embedded (1.101.6-arm-linux-gnueabihf) sha256=f3a6323bcf6761bab1e94379fe4df3582f53664fc9ecb506878f0369a7e8b5b5
-  sass-embedded (1.101.6-arm-linux-musleabihf) sha256=5f59087981a7a23f6165cf55e6d95043e8cd6384e70781701a5d3fa89786cbc4
-  sass-embedded (1.101.6-arm64-darwin) sha256=ea15579c067d794893b8259799434423f282646b64ceb434980bf4443be81888
-  sass-embedded (1.101.6-riscv64-linux-android) sha256=66c9858e96d4b2ac73bcb25389497938cce7a7048cf881c9d9a4a88037379dae
-  sass-embedded (1.101.6-riscv64-linux-gnu) sha256=9cc2834c53f3852cdd9b77dadf8b055b7fb0618f03282076c9eed88677394a8f
-  sass-embedded (1.101.6-riscv64-linux-musl) sha256=fef4c71fcdb6440a7146e5c4e0b4ed7bf45778994d174116d4a8566036cbd9d7
-  sass-embedded (1.101.6-x86_64-darwin) sha256=7307b9fb7e164759ef95ad7ce4a28c6ffe5be5a70aa9b11de3b15d9e5c62b3d5
-  sass-embedded (1.101.6-x86_64-linux-android) sha256=eeae95ec44aa4a43ddfa5a1f061d00f63a087b9368175e8f1b69b352635e446d
-  sass-embedded (1.101.6-x86_64-linux-gnu) sha256=f742f71ce987d201c7832618b0c00aa95c7e1baafe69897ea320fef056a661e2
-  sass-embedded (1.101.6-x86_64-linux-musl) sha256=c11a4a205cfa1b50d699eec412bf680b4e7c96cb9a3f3aad91461aef6d3bb267
+  sass-embedded (1.104.0) sha256=308c7cc890de96d77556d515e5958ba2fcfbc69978496ea2b2f0565dd5869bfd
+  sass-embedded (1.104.0-aarch64-linux-android) sha256=e273a0ea3a29b4933d30f663e88276982e4700a898c984c1ef6cfed56faecfc2
+  sass-embedded (1.104.0-aarch64-linux-gnu) sha256=99e2b95e8101928f8976c7a3f7cced5c5e4289ceb8aca0e1dedd9bb13645e417
+  sass-embedded (1.104.0-aarch64-linux-musl) sha256=d54f9dc45e753d29a999021f24cfc126b49c61f14bcb8e96209a02288cde22c3
+  sass-embedded (1.104.0-arm-linux-androideabi) sha256=f7aa8ec25c9be4dd91c66e55c56379de01fa07b0b721fe0b45528c7fd52c839d
+  sass-embedded (1.104.0-arm-linux-gnueabihf) sha256=5dfe35be85c0816131648da14312bc4981b1283d3c3aaaab7254b572420b6d93
+  sass-embedded (1.104.0-arm-linux-musleabihf) sha256=43d61264663409b268d46f33d2312b0084cb18b9af0c3d181563f5e05ab0053f
+  sass-embedded (1.104.0-arm64-darwin) sha256=b1409415e06931b43c2a498fc430fe8ddbad9706be5bb3c4e20b60c14f56b122
+  sass-embedded (1.104.0-riscv64-linux-android) sha256=4718d3d153c5332da42f4ca4d553642ed1c6d3a0cd047fe4cf3e4ff6ecab4e2c
+  sass-embedded (1.104.0-riscv64-linux-gnu) sha256=d3e217e7f845ab756d279a5f1954331bc6f6f1d56f955db2e06ba1e91276cc60
+  sass-embedded (1.104.0-riscv64-linux-musl) sha256=3ccab81e9f1f3a32364fc7bee111080545638aa93db3dd40a4d8b461aa5a01ca
+  sass-embedded (1.104.0-x86_64-darwin) sha256=d463b65e6fefcae614352f7a4dcea61d399f35a1238822b38d88471cee954717
+  sass-embedded (1.104.0-x86_64-linux-android) sha256=380d8fdfe6612a8e3fc48c38a67302053c8aa6cc166c450f084e77582f4b0105
+  sass-embedded (1.104.0-x86_64-linux-gnu) sha256=7aeaa07beff7db254836599f1524ac7b67216729613ebc57e3828b94345f0488
+  sass-embedded (1.104.0-x86_64-linux-musl) sha256=bc14555f68aa7057e923d400726c1623bb603101eef6340962e4e80ee89e67ba
   terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
   unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
-  webrick (1.8.2) sha256=431746a349199546ff9dd272cae10849c865f938216e41c402a6489248f12f21
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
 
 BUNDLED WITH
-  4.0.17
+  4.0.20

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Install bundler using the same version as specified at the end of the
 `Gemfile.lock` file in the project root:
 
 ```bash
-gem install bundler -v '=4.0.17'
+gem install bundler -v '=4.0.20'
 ```
 
 Install gems for site:


### PR DESCRIPTION
Refresh the locked gem versions and the bundler pin.

- `json` 2.21.1 to 2.21.2
- `sass-embedded` 1.101.6 to 1.104.0
- `google-protobuf` 4.35.1 to 4.36.1
- `csv` 3.3.5 to 3.3.6
- `webrick` 1.8.2 to 1.9.2, which also widens the `Gemfile` constraint to `~> 1.9.2`
- `bundler` 4.0.17 to 4.0.20, with the matching `README.md` instruction

The `json` update contains the fix for
[GHSA-9hj4-r449-hfvc](https://github.com/ruby/json/security/advisories/GHSA-9hj4-r449-hfvc)
/ CVE-2026-71847, a use-after-free in `JSON::ResumableParser`. This supersedes
#845, which can be closed once this merges.

The remaining outdated gems, `liquid`, `rouge`, `terminal-table`, and
`unicode-display_width`, are held back by the constraints of `jekyll` 4.4.1 and
cannot move without a Jekyll upgrade.

`RUBY_VERSION` in `netlify.toml` already matches the current stable Ruby 4.0.6,
so it needs no change.

## Testing

- `bundle exec jekyll build --future` completes without errors
- `bundle exec jekyll serve` runs on the updated webrick, and the home page,
  blog index, and ecosystem pages render correctly